### PR TITLE
[BOJ 2503] 숫자 야구 / S3

### DIFF
--- a/BruteForce/BOJ2503/eunjin.py
+++ b/BruteForce/BOJ2503/eunjin.py
@@ -1,0 +1,54 @@
+from itertools import permutations
+
+# 입력 받기
+N = int(input())
+
+num = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+
+# 숫자 3개의 모든 조합 생성
+perms = []
+for elem in list(permutations(num, 3)):
+    perms.append(''.join(elem[0:3]))
+
+# 결과적으로 가능한 조합들만을 저장할 리스트
+result_list = perms[:]
+
+qna = {}
+
+# 질문과 답변 저장
+for _ in range(N):
+    q, s, b = input().split()
+    s = int(s)
+    b = int(b)
+    qna[q] = [s, b]
+
+
+def countBall(ans, inp):
+    result = 0
+    for i in range(0, 3):
+        if (ans[i] in inp and ans[i] != inp[i]):  # strike의 개수는 제외해야 하므로
+            result += 1
+    return result
+
+
+def countStrike(ans, inp):
+    result = 0
+    for i in range(0, 3):
+        if(ans[i] == inp[i]):
+            result += 1
+    return result
+
+
+# 전체 조합에서 질문과 답변 바탕으로 불가능한 조합을 제거
+# 각 후보 조합마다 qna를 다 돌면서 얘가 가능한 애인지 아닌지 판단
+for hubo in perms:
+    for key in qna:
+        # 각 hubo와 key를 비교해 strike와 ball 개수 카운트
+        strikes = countStrike(key, hubo)
+        balls = countBall(key, hubo)
+        # strike와 ball 개수가 답변과 맞지 않으면 후보가 아니므로 결과 리스트에서 제거
+        if(strikes != qna[key][0] or balls != qna[key][1]):
+            if(hubo in result_list):
+                result_list.remove(hubo)
+
+print(len(result_list))


### PR DESCRIPTION
### 🚀 문제 번호
Resolve: {#37}  
<br/>

### 🔍 구현 방법
<!-- 문제를 해결한 구체적인 방법을 설명해주세요. -->
처음에는 각 질문과 답변을 바탕으로 가능한 모든 조합을 만들어서 결과 리스트에 추가하는 방식으로 해보려고 했는데, 그렇게 되면 첫번째 질문 답변에서는 가능했던 후보 조합들이 두번째 질문 답변에 의해서 불가능해져서 후보를 삭제해야되는 경우가 생겼습니다. 그래서 하나의 질문 답변에서 시작해 전체를 구하는 방식 말고, 전체 후보를 먼저 구해놓고 각 질문 답변에 의해 불가능해지는 후보를 삭제하는 방식으로 생각했습니다. permutations를 이용해 1~9까지의 숫자로 만들 수 있는 가능한 조합을 모두 만들고, 이 후보와 모든 질문/답변을 비교해 얘가 가능한 후보인지 판단했습니다. 질문/답변을 비교할 때는 후보와 질문 string을 비교해 strike와 ball 개수를 셌을 때, 그게 답변으로 받은 개수와 일치하는지 여부에 따라 가능/불가능 한 조합임을 판단했습니다.
```
from itertools import permutations

# 입력 받기
N = int(input())

num = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]

# 숫자 3개의 모든 조합 생성
perms = []
for elem in list(permutations(num, 3)):
    perms.append(''.join(elem[0:3]))

# 결과적으로 가능한 조합들만을 저장할 리스트
result_list = perms[:]

qna = {}

# 질문과 답변 저장
for _ in range(N):
    q, s, b = input().split()
    s = int(s)
    b = int(b)
    qna[q] = [s, b]


def countBall(ans, inp):
    result = 0
    for i in range(0, 3):
        if (ans[i] in inp and ans[i] != inp[i]):  # strike의 개수는 제외해야 하므로
            result += 1
    return result


def countStrike(ans, inp):
    result = 0
    for i in range(0, 3):
        if(ans[i] == inp[i]):
            result += 1
    return result


# 전체 조합에서 질문과 답변 바탕으로 불가능한 조합을 제거
# 각 후보 조합마다 qna를 다 돌면서 얘가 가능한 애인지 아닌지 판단
for hubo in perms:
    for key in qna:
        # 각 hubo와 key를 비교해 strike와 ball 개수 카운트
        strikes = countStrike(key, hubo)
        balls = countBall(key, hubo)
        # strike와 ball 개수가 답변과 맞지 않으면 후보가 아니므로 결과 리스트에서 제거
        if(strikes != qna[key][0] or balls != qna[key][1]):
            if(hubo in result_list):
                result_list.remove(hubo)

print(len(result_list))

```
<br/>

### ⭐️ 리뷰 Point
<!-- 이 PR에 대한 논의하고 싶은 사항이나 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


