### PR TITLE
[BOJ 14889] 스타트와 링크 / S1

### DIFF
--- a/BruteForce/BOJ14889/eunjin.py
+++ b/BruteForce/BOJ14889/eunjin.py
@@ -1,0 +1,32 @@
+from itertools import combinations
+# 입력 받기
+N = int(input())
+
+S = [list(map(int, input().split())) for _ in range(N)]
+
+arr = [i for i in range(0, N)]
+
+minDiff = 9999999
+
+# start팀이 될 N/2명의 조합 생성
+for start in combinations(arr, N//2):
+    link = [x for x in arr if x not in start]
+    startPoint = 0
+    linkPoint = 0
+
+    # 0 ~ N-1번까지 돌면서 i가 start팀이면 start 포인트 합산, link팀이면 link 포인트 합산
+    for i in range(N):
+        if arr[i] in start:
+            for j in start:
+                startPoint += S[i][j]
+        else:
+            for j in link:
+                linkPoint += S[i][j]
+
+    diff = abs(startPoint-linkPoint)
+
+    if(diff < minDiff):
+        minDiff = diff
+
+
+print(minDiff)


### PR DESCRIPTION
### 🚀 문제 번호
Resolve: {#57}  
<br/>

### 🔍 구현 방법
<!-- 문제를 해결한 구체적인 방법을 설명해주세요. -->
N/2명의 조합 시간 복잡도는 20명 중 10명을 고르는 경우가 가장 커진다. 20C10 = 184756 이다.
그 후, 각 조합마다 for문을 N번 도는 연산 N번, 그 안에서 start, link를 도는 연산 N/2번을 실행하므로 184756 * 20 * 10번의 연산을 수행하게 된다. 총 36,951,200번 < 1억이므로 1초 이내에 실행이 가능하다.
따라서 전체를 탐색하는 브루트포스 방식으로 해결 가능하다.

```
from itertools import combinations
# 입력 받기
N = int(input())

S = [list(map(int, input().split())) for _ in range(N)]

arr = [i for i in range(0, N)]

minDiff = 9999999

# start팀이 될 N/2명의 조합 생성
for start in combinations(arr, N//2):
    link = [x for x in arr if x not in start]
    startPoint = 0
    linkPoint = 0

    # 0 ~ N-1번까지 돌면서 i가 start팀이면 start 포인트 합산, link팀이면 link 포인트 합산
    for i in range(N):
        if arr[i] in start:
            for j in start:
                startPoint += S[i][j]
        else:
            for j in link:
                linkPoint += S[i][j]

    diff = abs(startPoint-linkPoint)

    if(diff < minDiff):
        minDiff = diff


print(minDiff)

```
<br/>

### ⭐️ 리뷰 Point
<!-- 이 PR에 대한 논의하고 싶은 사항이나 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


