### PR TITLE
[BOJ 11053] 가장 긴 증가하는 부분 수열 / S2

### DIFF
--- a/DP/BOJ11053/eunjin.py
+++ b/DP/BOJ11053/eunjin.py
@@ -1,0 +1,37 @@
+# 입력 받기
+N = int(input())
+A = list(map(int, input().split()))
+
+# dp[i]
+# 0~i번째 원소 중, i번째 원소를 포함하는 가장 긴 증가하는 부분 수열 길이
+dp = [1]*N
+
+for i in range(1, N):
+    low_idxs = []     # low_idxs: i번째 원소보다 작은 원소들의 인덱스 list
+    for x in range(i-1, -1, -1):
+        # print("i:", i, ", x:", x)
+        if(A[i] > A[x]):
+            low_idxs.append(x)
+
+    #print("low_idx:", low_idxs)
+
+    if(low_idxs):
+        max_dp_idx = low_idxs[0]
+        for idx in low_idxs:
+            if(dp[idx] > dp[max_dp_idx]):
+                max_dp_idx = idx
+        # print("i:", i, ", max_dp_idx:", max_dp_idx)
+
+        dp[i] = dp[max_dp_idx]+1
+    # print("dp:", dp)
+
+# print(dp)
+print(max(dp))
+
+
+# for i in range(1, N):
+#     for x in range(i):
+#         if(A[i] > A[x]):
+#             dp[i] = max(dp[i], dp[x]+1)
+
+# print(max(dp))


### PR DESCRIPTION
### 🚀 문제 번호
Resolve: {#83}  
<br/>

### 🔍 구현 방법
<!-- 문제를 해결한 구체적인 방법을 설명해주세요. -->
N이 1000까지 가능하므로 브루트포스 방식 이용 불가
앞에서부터 매번 증가하는 원소만을 선택하는 그리디 방식도 이용 불가 (앞에서 몇개의 원소를 포기하더라도 뒤에서 더 많은 원소를 선택하는 이득이 생길 수 있으므로)
=> dp 방식으로 풀어야 한다
dp list를 0~i번째까지의 원소 중에서 i번째 원소를 포함하는 가장 긴 증가하는 부분 수열 길이로 뒀습니다.
0~i-1번째 인덱스까지의 원소 중에서 i번째 원소보다 작은 원소들을 저장 후, 그 원소들 중에 가장 큰 dp 값을 갖는 애 하나를 찾아서 i번째 dp 값을 업데이트 했습니다.

```
# 입력 받기
N = int(input())
A = list(map(int, input().split()))

# dp[i]
# 0~i번째 원소 중, i번째 원소를 포함하는 가장 긴 증가하는 부분 수열 길이
dp = [1]*N

for i in range(1, N):
    low_idxs = []     # low_idxs: i번째 원소보다 작은 원소들의 인덱스 list
    for x in range(i-1, -1, -1):
        # print("i:", i, ", x:", x)
        if(A[i] > A[x]):
            low_idxs.append(x)

    #print("low_idx:", low_idxs)

    if(low_idxs):
        max_dp_idx = low_idxs[0]
        for idx in low_idxs:
            if(dp[idx] > dp[max_dp_idx]):
                max_dp_idx = idx
        # print("i:", i, ", max_dp_idx:", max_dp_idx)

        dp[i] = dp[max_dp_idx]+1
    # print("dp:", dp)

# print(dp)
print(max(dp))
```

그런데 다른 풀이들을 보니까 이렇게 간단하게도 가능하더라구요..! dp[i]를 계속 max 비교해서 덮어써가면서 업데이트 하는 방식인 것 같아요
```
for i in range(1, N):
     for x in range(i):
         if(A[i] > A[x]):
             dp[i] = max(dp[i], dp[x]+1)

 print(max(dp))
```
<br/>

### ⭐️ 리뷰 Point
<!-- 이 PR에 대한 논의하고 싶은 사항이나 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


