### PR TITLE
[BOJ 2775] 연속합 / S2

### DIFF
--- a/DP/BOJ1912/eunjin.py
+++ b/DP/BOJ1912/eunjin.py
@@ -1,0 +1,24 @@
+# 입력 받기
+N = int(input())
+input_arr = list(map(int, input().split()))
+
+# n이 100,000까지 가능하므로 브루트포스 불가
+# 앞에서부터 합이 최대가 되도록 정수 선택한다고해도 뒤에서 더 큰 최대 합을 갖는 구간이 생길 수 있으므로 그리디 불가
+
+arr = [0]
+for i in range(N):
+    arr.append(input_arr[i])
+
+# dp[x]: x를 포함하는, x까지의 최대 연속 합
+# x번째 정수까지의 최대 연속 합은 x-1번째 정수까지의 최대 연속합에 x 자신까지 더한 값과, x 자신 중 최댓값이다
+# dp[x-1]+x 가 더 크면 x-1번째 정수까지 고르고 x도 고르면 되고, 그냥 x가 더 크면 x-1번째까지의 연속 합을 포기하고 x 자신만 선택하면 된다
+dp = [0] * (N+1)
+if(N == 1):
+    print(arr[1])
+else:
+    dp[0] = min(input_arr)
+    dp[1] = arr[1]
+    for x in range(2, N+1):
+        dp[x] = max(dp[x-1]+arr[x], arr[x])
+    # print(dp)
+    print(max(dp))


### PR DESCRIPTION
### 🚀 문제 번호
Resolve: {#107}  
<br/>

### 🔍 구현 방법
<!-- 문제를 해결한 구체적인 방법을 설명해주세요. -->
n이 100,000까지 가능하므로 브루트포스 불가
앞에서부터 합이 최대가 되도록 정수 선택한다고해도 뒤에서 더 큰 최대 합을 갖는 구간이 생길 수 있으므로 그리디 불가
=> dp로 풀었습니다.

dp[x]: x를 포함하는, x까지의 최대 연속 합으로 두었습니다.
x번째 정수까지의 최대 연속 합은 x-1번째 정수까지의 최대 연속합에 x 자신까지 더한 값과, x 자신 중의 최댓값.
dp[x-1]+x 가 더 크면 x-1번째 정수까지 고르고 x도 고르면 되고, 그냥 x가 더 크면 x-1번째까지의 연속 합을 포기하고 x 자신만 선택하면 된다고 생각했습니다.
정수가 모두 음수인 경우가 있어서 dp[0]은 min(input_arr)로 설정했습니다.

```
# 입력 받기
N = int(input())
input_arr = list(map(int, input().split()))

# n이 100,000까지 가능하므로 브루트포스 불가
# 앞에서부터 합이 최대가 되도록 정수 선택한다고해도 뒤에서 더 큰 최대 합을 갖는 구간이 생길 수 있으므로 그리디 불가

arr = [0]
for i in range(N):
    arr.append(input_arr[i])

# dp[x]: x를 포함하는, x까지의 최대 연속 합
# x번째 정수까지의 최대 연속 합은 x-1번째 정수까지의 최대 연속합에 x 자신까지 더한 값과, x 자신 중 최댓값이다
# dp[x-1]+x 가 더 크면 x-1번째 정수까지 고르고 x도 고르면 되고, 그냥 x가 더 크면 x-1번째까지의 연속 합을 포기하고 x 자신만 선택하면 된다
dp = [0] * (N+1)
if(N == 1):
    print(arr[1])
else:
    dp[0] = min(input_arr)
    dp[1] = arr[1]
    for x in range(2, N+1):
        dp[x] = max(dp[x-1]+arr[x], arr[x])
    # print(dp)
    print(max(dp))
```
<br/>

### ⭐️ 리뷰 Point
<!-- 이 PR에 대한 논의하고 싶은 사항이나 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


