### PR TITLE
[BOJ 2110] 공유기 설치 / G4

### DIFF
--- a/ParametricSearch/BOJ2110/eunjin.py
+++ b/ParametricSearch/BOJ2110/eunjin.py
@@ -1,0 +1,38 @@
+# 입력 받기
+N, C = map(int, input().split())
+X = []
+for _ in range(N):
+    X.append(int(input()))
+
+
+def is_possible(h):
+    global N, C, X
+    sorted_arr = sorted(X)
+    last_idx = 0  # 가장 첫 집에 공유기 설치하는게 무조건 이득
+    cnt = 1
+    # 그리디 방식으로 앞에서부터 선택해가며 간격이 h이상인지 판단한다.
+    for i in range(1, N):
+        if(sorted_arr[i]-sorted_arr[last_idx] >= h):
+            last_idx = i
+            cnt += 1
+
+    return cnt >= C
+
+# N이 최대 200,000이므로 브루트포스 풀이 불가능
+# 가장 인접한 두 공유기 사이의 거리를 k로 뒀을 때
+# 아래와 같이 어느 순간 최소 k거리를 두고 공유기 설치 불가능한 지점이 생긴다.
+# 1 2 3 4 ... x-1 x x+1 x+2 ...
+# T T T T      T  F  F   F
+
+
+# parametric search로 x를 찾는다.
+cur = -1
+step = max(X)+1
+while(step != 0):
+    #print("started, step:", step)
+    while(cur+step <= max(X)+1 and is_possible(cur+step)):
+        cur += step
+        #print("cur:", cur)
+    step //= 2
+
+print(cur)


### PR DESCRIPTION
### 🚀 문제 번호
Resolve: {#95}  
<br/>

### 🔍 구현 방법
<!-- 문제를 해결한 구체적인 방법을 설명해주세요. -->
N이 최대 200000이므로 브루트포스 풀이는 불가능하고, 가장 인접한 두 공유기 사이의 거리를 k로 뒀을 때
                   k: 1 2 3 4 ... x-1 x x+1 x+2 ...
설치 가능 여부: T T T T      T  F   F     F
위와 같이 어느 k의 값부터는 공유기 설치가 불가능해지고, 그 전까지는 모두 공유기 설치가 가능한 상태입니다.
이렇게 T의 연속이다가 어느 값부터 F의 연속으로 바뀌는 경우, 파라매트릭 서치를 사용할 수 있습니다.
cur은 현재 위치, step은 나아갈 분량으로 두고, cur 위치에서 step만큼 나아갔을 때 설치 가능 여부가 T이면 나아가고, F이면 나아가지 않고 step을 반으로 줄여나가는 방식으로 구현했습니다.

k 거리를 두고 공유기를 설치할 수 있는지 여부는 그리디 방식으로 판단했습니다.
```
# 입력 받기
N, C = map(int, input().split())
X = []
for _ in range(N):
    X.append(int(input()))


def is_possible(h):
    global N, C, X
    sorted_arr = sorted(X)
    last_idx = 0  # 가장 첫 집에 공유기 설치하는게 무조건 이득
    cnt = 1
    # 그리디 방식으로 앞에서부터 선택해가며 간격이 h이상인지 판단한다.
    for i in range(1, N):
        if(sorted_arr[i]-sorted_arr[last_idx] >= h):
            last_idx = i
            cnt += 1

    return cnt >= C

# N이 최대 200,000이므로 브루트포스 풀이 불가능
# 가장 인접한 두 공유기 사이의 거리를 k로 뒀을 때
# 아래와 같이 어느 순간 최소 k거리를 두고 공유기 설치 불가능한 지점이 생긴다.
# 1 2 3 4 ... x-1 x x+1 x+2 ...
# T T T T      T  F  F   F


# parametric search로 x를 찾는다.
cur = -1
step = max(X)+1
while(step != 0):
    #print("started, step:", step)
    while(cur+step <= max(X)+1 and is_possible(cur+step)):
        cur += step
        #print("cur:", cur)
    step //= 2

print(cur)
```
<br/>

### ⭐️ 리뷰 Point
<!-- 이 PR에 대한 논의하고 싶은 사항이나 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


