### PR TITLE
[BOJ 11053] 가장 긴 증가하는 부분 수열 / S2

### DIFF
--- a/DP/BOJ11053/hyeonji.py
+++ b/DP/BOJ11053/hyeonji.py
@@ -1,0 +1,15 @@
+import sys
+input=sys.stdin.readline
+
+n=int(input())  # 수열 A의 크기
+A=list(map(int,input().split()))  # 수열 A
+
+d=[1 for i in range(n)]
+
+# LIS 알고리즘 수행.
+for i in range(1,n):
+    for j in range(i):
+        if A[j]<A[i]:
+            d[i]=max(d[i],d[j]+1)
+
+print(max(d))


### PR DESCRIPTION
### 🚀 문제 번호
Resolve: {#83}  
<br/>

### 🔍 구현 방법
<!-- 문제를 해결한 구체적인 방법을 설명해주세요. -->
앞에서 몇 개의 원소를 포기하더라도 뒤에서 더 많은 원소를 선택하는 것이 전체적으로 이득이 될 수 있기 때문에 이에 유의하며, 가장 긴 증가하는 부분 수열의 "길이" 만 출력하면 되기 때문에 LIS 알고리즘으로 구현하였습니다.
```
n=int(input())  # 수열 A의 크기
A=list(map(int,input().split()))  # 수열 A

d=[1 for i in range(n)]

# LIS 알고리즘 수행.
for i in range(1,n):
    for j in range(i):
        if A[j]<A[i]:
            d[i]=max(d[i],d[j]+1)

print(max(d))
```
<br/>

### ⭐️ 리뷰 Point
<!-- 이 PR에 대한 논의하고 싶은 사항이나 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


