### PR TITLE
[BOJ 1012] 유기농 배추 / S2

### DIFF
--- a/DFS & BFS/BOJ1012/eunjin.py
+++ b/DFS & BFS/BOJ1012/eunjin.py
@@ -1,0 +1,45 @@
+import sys
+sys.setrecursionlimit(100000)
+
+# 입력 받기
+T = int(input())
+
+
+def dfs(y, x):
+    global visited, matrix
+    if(visited[y][x]):
+        return
+
+    visited[y][x] = True
+
+    dy = [-1, 0, 1, 0]
+    dx = [0, 1, 0, -1]
+
+    for i in range(4):
+        ny = y + dy[i]
+        nx = x + dx[i]
+        if(0 <= ny < N and 0 <= nx < M) and matrix[ny][nx] == 1:
+            dfs(ny, nx)
+
+
+t = 0
+while(t < T):
+    t += 1
+
+    M, N, K = map(int, input().split())
+
+    matrix = [[0]*M for _ in range(N)]
+
+    for _ in range(K):
+        X, Y = map(int, input().split())
+        matrix[Y][X] = 1
+
+    visited = [[False]*M for _ in range(N)]
+    cnt = 0
+
+    for y in range(N):
+        for x in range(M):
+            if(matrix[y][x] == 1 and not visited[y][x]):
+                cnt += 1
+                dfs(y, x)
+    print(cnt)


### PR DESCRIPTION
### 🚀 문제 번호
Resolve: {#152}  
<br/>

### 🔍 구현 방법
<!-- 문제를 해결한 구체적인 방법을 설명해주세요. -->
matrix 전체를 돌면서, 값이 1이고 아직 방문하지 않은 경우에 해당 노드를 시작으로 dfs 탐색을 했습니다. 이 때, cnt+=1을 해 주어서 영역의 개수를 업데이트 했습니다. ```sys.setrecursionlimit(100000)```를 하지 않고 제출했더니 RecursionError가 발생해서 재귀 호출 제한을 늘려주도록 해당 코드를 추가했더니 잘 돌아갔습니다!
```
import sys
sys.setrecursionlimit(100000)

# 입력 받기
T = int(input())


def dfs(y, x):
    global visited, matrix
    if(visited[y][x]):
        return

    visited[y][x] = True

    dy = [-1, 0, 1, 0]
    dx = [0, 1, 0, -1]

    for i in range(4):
        ny = y + dy[i]
        nx = x + dx[i]
        if(0 <= ny < N and 0 <= nx < M) and matrix[ny][nx] == 1:
            dfs(ny, nx)


t = 0
while(t < T):
    t += 1

    M, N, K = map(int, input().split())

    matrix = [[0]*M for _ in range(N)]

    for _ in range(K):
        X, Y = map(int, input().split())
        matrix[Y][X] = 1

    visited = [[False]*M for _ in range(N)]
    cnt = 0

    for y in range(N):
        for x in range(M):
            if(matrix[y][x] == 1 and not visited[y][x]):
                cnt += 1
                dfs(y, x)
    print(cnt)
```
<br/>

### ⭐️ 리뷰 Point
<!-- 이 PR에 대한 논의하고 싶은 사항이나 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


