### PR TITLE
[BOJ 1753] 최단경로 / G4

### DIFF
--- a/Dijkstra/BOJ1753/eunjin.py
+++ b/Dijkstra/BOJ1753/eunjin.py
@@ -1,0 +1,36 @@
+from queue import PriorityQueue
+import sys
+input = sys.stdin.readline
+
+# 입력 받기
+V, E = map(int, input().split())
+start_node = int(input())
+
+adj_list = [[] for _ in range(V+1)]
+INF = int(1e12)
+dist = [INF] * (V+1)
+dist[0] = 0
+
+# 인접리스트 생성
+for _ in range(E):
+    u, v, w = map(int, input().split())
+    adj_list[u].append([w, v])  # dist, next_node
+
+pq = PriorityQueue()
+pq.put([0, start_node])
+dist[start_node] = 0
+
+while not pq.empty():
+    curr_dist, curr_node = pq.get()
+    for adj_dist, adj_node in adj_list[curr_node]:
+        temp_dist = curr_dist+adj_dist
+        if(temp_dist < dist[adj_node]):
+            dist[adj_node] = temp_dist
+            pq.put([temp_dist, adj_node])
+
+
+for elem in dist[1:]:
+    if(elem == INF):
+        print("INF")
+    else:
+        print(elem)


### PR DESCRIPTION
### 🚀 문제 번호
Resolve: {#143}  
<br/>

### 🔍 구현 방법
<!-- 문제를 해결한 구체적인 방법을 설명해주세요. -->
가중치가 있는 그래프에서의 최단 경로를 찾아야하므로 다익스트라 알고리즘을 사용했습니다. priorityQueue를 사용해 특정노드에서 출발하는 경로 중 가중치가 가장 적은 노드를 뽑고, 기존에 가지고 있던 거리와 가중치를 비교해서 최소 경로를 따라갈 수 있도록 했습니다.
```
from queue import PriorityQueue
import sys
input = sys.stdin.readline

# 입력 받기
V, E = map(int, input().split())
start_node = int(input())

adj_list = [[] for _ in range(V+1)]
INF = int(1e12)
dist = [INF] * (V+1)
dist[0] = 0

# 인접리스트 생성
for _ in range(E):
    u, v, w = map(int, input().split())
    adj_list[u].append([w, v])  # dist, next_node

pq = PriorityQueue()
pq.put([0, start_node])
dist[start_node] = 0

while not pq.empty():
    curr_dist, curr_node = pq.get()
    for adj_dist, adj_node in adj_list[curr_node]:
        temp_dist = curr_dist+adj_dist
        if(temp_dist < dist[adj_node]):
            dist[adj_node] = temp_dist
            pq.put([temp_dist, adj_node])


for elem in dist[1:]:
    if(elem == INF):
        print("INF")
    else:
        print(elem)
```
<br/>

### ⭐️ 리뷰 Point
<!-- 이 PR에 대한 논의하고 싶은 사항이나 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


