### PR TITLE
[BOJ 1504] 특정한 최단 경로 / G4

### DIFF
--- a/Dijkstra/BOJ1504/eunjin.py
+++ b/Dijkstra/BOJ1504/eunjin.py
@@ -1,0 +1,48 @@
+from queue import PriorityQueue
+# 입력 받기
+N, E = map(int, input().split())
+
+INF = int(1e12)
+
+
+def dijkstra(start_node):
+    global N, adj_list
+
+    dist = [INF]*(N+1)
+
+    pq = PriorityQueue()
+    dist[start_node] = 0
+    pq.put([0, start_node])
+
+    while not pq.empty():
+        cur_dist, cur_node = pq.get()
+        for adj_dist, adj_node in adj_list[cur_node]:
+            temp_dist = cur_dist + adj_dist
+            if temp_dist < dist[adj_node]:
+                dist[adj_node] = temp_dist
+                pq.put([temp_dist, adj_node])
+
+    return dist
+
+
+adj_list = [[] for _ in range(N+1)]
+
+for _ in range(E):
+    a, b, c = map(int, input().split())
+    adj_list[a].append([c, b])  # dist, node
+    adj_list[b].append([c, a])  # 양방향이므로
+
+
+v1, v2 = map(int, input().split())
+
+
+dist_1 = dijkstra(1)
+dist_v1 = dijkstra(v1)
+dist_v2 = dijkstra(v2)
+
+case1 = dist_1[v1] + dist_v1[v2] + dist_v2[N]
+case2 = dist_1[v2] + dist_v2[v1] + dist_v1[N]
+
+result = min(case1, case2)
+
+print(result if result < INF else -1)


### PR DESCRIPTION
### 🚀 문제 번호
Resolve: {#144}  
<br/>

### 🔍 구현 방법
<!-- 문제를 해결한 구체적인 방법을 설명해주세요. -->
간선마다 가중치가 있으므로 다익스트라를 사용해 최단 경로를 구했습니다.
반드시 거쳐야하는 두 지점 v1,v2라는 조건에 대해서는 경우를 2가지로 나누어서 1 -> v1 -> v2 -> N 경로와, 1 -> v2 -> v1 -> N 경로로 생각했습니다. dist 배열을 시작점이 1인 것, v1인 것, v2인 것에 대해 모두 구해서 두 경우의 최단 경로를 계산했습니다.
```
from queue import PriorityQueue

# 입력 받기
N, E = map(int, input().split())

INF = int(1e12)


def dijkstra(start_node):
    global N, adj_list

    dist = [INF]*(N+1)

    pq = PriorityQueue()
    dist[start_node] = 0
    pq.put([0, start_node])

    while not pq.empty():
        cur_dist, cur_node = pq.get()
        for adj_dist, adj_node in adj_list[cur_node]:
            temp_dist = cur_dist + adj_dist
            if temp_dist < dist[adj_node]:
                dist[adj_node] = temp_dist
                pq.put([temp_dist, adj_node])

    return dist


adj_list = [[] for _ in range(N+1)]

for _ in range(E):
    a, b, c = map(int, input().split())
    adj_list[a].append([c, b])  # dist, node
    adj_list[b].append([c, a])  # 양방향이므로


v1, v2 = map(int, input().split())


dist_1 = dijkstra(1)
dist_v1 = dijkstra(v1)
dist_v2 = dijkstra(v2)

case1 = dist_1[v1] + dist_v1[v2] + dist_v2[N]
case2 = dist_1[v2] + dist_v2[v1] + dist_v1[N]

result = min(case1, case2)

print(result if result < INF else -1)
```
<br/>

### ⭐️ 리뷰 Point
<!-- 이 PR에 대한 논의하고 싶은 사항이나 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


