### PR TITLE
[BOJ 1238] 파티 / G3

### DIFF
--- a/Dijkstra/BOJ1238/eunjin.py
+++ b/Dijkstra/BOJ1238/eunjin.py
@@ -1,0 +1,44 @@
+from queue import PriorityQueue
+
+# 입력 받기
+N, M, X = map(int, input().split())
+
+adj_list = [[] for _ in range(M+1)]
+adj_list_reverse = [[] for _ in range(M+1)]
+for _ in range(M):
+    start, end, t = map(int, input().split())
+    adj_list[start].append([end, t])  # node, dist
+    adj_list_reverse[end].append([start, t])  # node, dist
+
+
+INF = int(1e12)
+
+
+def dijkstra(adj_list, start_node):
+    global N
+
+    dist = [INF] * (N+1)
+
+    pq = PriorityQueue()
+    pq.put([0, start_node])
+    dist[start_node] = 0
+
+    while not pq.empty():
+        cur_dist, cur_node = pq.get()
+        for adj_node, adj_dist in adj_list[cur_node]:
+            temp_dist = cur_dist + adj_dist
+            if(temp_dist < dist[adj_node]):
+                dist[adj_node] = temp_dist
+                pq.put([temp_dist, adj_node])
+
+    return dist
+
+
+dist = dijkstra(adj_list, X)
+dist_reverse = dijkstra(adj_list_reverse, X)
+
+result = -1
+for i in range(1, N+1):
+    result = max(result, dist[i]+dist_reverse[i])
+
+print(result)


### PR DESCRIPTION
### 🚀 문제 번호
Resolve: {#146}  
<br/>

### 🔍 구현 방법
<!-- 문제를 해결한 구체적인 방법을 설명해주세요. -->
모든 노드 -> X -> 모든 노드 로 이동하는 최단 경로를 구해야 하므로 다익스트라를 사용했습니다.
다익스트라로 X -> 모든 노드로 이동하는 최단 경로를 구할 수 있는데, 여기서는 모든 노드 -> X로 이동하는 최단 경로도 구해야하는 게 문제였습니다. 모든 노드 -> X로 이동하는 경로를 구하기 위해서 입력으로 받았던 간선들의 start node와 end node를 역방향으로 바꾸어서 별도로 저장하고, 이 adj_list_reverse에 다익스트라를 적용해서 X -> 모든 노드로 이동하는 경로 (사실은 모든 노드 -> X로 이동하는 경로)를 구했습니다.
```
from queue import PriorityQueue

# 입력 받기
N, M, X = map(int, input().split())

adj_list = [[] for _ in range(M+1)]
adj_list_reverse = [[] for _ in range(M+1)]
for _ in range(M):
    start, end, t = map(int, input().split())
    adj_list[start].append([end, t])  # node, dist
    adj_list_reverse[end].append([start, t])  # node, dist


INF = int(1e12)


def dijkstra(adj_list, start_node):
    global N

    dist = [INF] * (N+1)

    pq = PriorityQueue()
    pq.put([0, start_node])
    dist[start_node] = 0

    while not pq.empty():
        cur_dist, cur_node = pq.get()
        for adj_node, adj_dist in adj_list[cur_node]:
            temp_dist = cur_dist + adj_dist
            if(temp_dist < dist[adj_node]):
                dist[adj_node] = temp_dist
                pq.put([temp_dist, adj_node])

    return dist


dist = dijkstra(adj_list, X)
dist_reverse = dijkstra(adj_list_reverse, X)

result = -1
for i in range(1, N+1):
    result = max(result, dist[i]+dist_reverse[i])

print(result)
```
<br/>

### ⭐️ 리뷰 Point
<!-- 이 PR에 대한 논의하고 싶은 사항이나 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


