### PR TITLE
241112 : [BOJ 1916] 최소비용 구하기 / G5

### DIFF
--- a/_eunjin/eunjin_1916.py
+++ b/_eunjin/eunjin_1916.py
@@ -1,0 +1,38 @@
+import sys
+import heapq
+input = sys.stdin.readline
+
+INF = int(1e9)
+
+# 입력 받기
+N = int(input())
+M = int(input())
+
+adj_list = [[] for _ in range(N+1)]
+for _ in range(M):
+    u, v, w = map(int, input().split())
+    adj_list[u].append((v, w))
+
+start, end = map(int, input().split())
+
+# 다익스트라 알고리즘 실행
+dist = [INF] * (N+1)
+
+
+def dijkstra(start):
+    q = []
+    dist[start] = 0
+    heapq.heappush(q, [0, start])
+    while q:
+        cur_dist, cur_node = heapq.heappop(q)
+        if dist[cur_node] < cur_dist:
+            continue
+        for adj_node, adj_dist in adj_list[cur_node]:
+            temp_dist = cur_dist + adj_dist
+            if temp_dist < dist[adj_node]:
+                dist[adj_node] = temp_dist
+                heapq.heappush(q, [temp_dist, adj_node])
+
+
+dijkstra(start)
+print(dist[end])


### PR DESCRIPTION
### 🚀 문제 번호
Resolve: {#186}  
<br/>

### 🔍 구현 방법
<!-- 문제를 해결한 구체적인 방법을 설명해주세요. -->
버스 비용이라는 가중치가 있는 그래프의 탐색이므로 다익스트라를 이용했습니다.
그런데 다익스트라 기본 코드로 실행해도 계속 시간초과가 나서,, 검색을 해보니 큐에서 노드를 꺼냈을 때
```
        if dist[cur_node] < cur_dist: # dist에 이미 최소 거리가 저장되어 있다면 이 노드의 인접 노드는 추가X
            continue
```
이렇게 dist 배열에 저장된 해당 노드의 거리가 방금 꺼낸 노드 거리보다 작다면 아예 cur_node의 인접 노드를 큐에 넣지 않도록 하는 최적화 방법을 사용해야 하더라구요..! 이 부분이 없으면 굳이 탐색할 필요가 없는 최단 거리가 아닌 경로까지 큐에 넣게 되어서 불필요한 연산이 추가되는 것 같습니다.... 앞으로 다익스트라는 아예 이 코드까지 추가해서 기억해두어야 할 것 같아요..
그리고 queue 모듈의 PriorityQueue보다 heapq 모듈이 속도가 약간 더 빠르다고 해서,, 앞으로는 heapq 다익스트라 코드로 사용해야겠습니다..!
```
import sys
import heapq
input = sys.stdin.readline

INF = int(1e9)

# 입력 받기
N = int(input())
M = int(input())

adj_list = [[] for _ in range(N+1)]
for _ in range(M):
    u, v, w = map(int, input().split())
    adj_list[u].append((v, w))

start, end = map(int, input().split())

# 다익스트라 알고리즘 실행
dist = [INF] * (N+1)


def dijkstra(start):
    q = []
    dist[start] = 0
    heapq.heappush(q, [0, start])
    while q:
        cur_dist, cur_node = heapq.heappop(q)
        if dist[cur_node] < cur_dist: # dist에 이미 최소 거리가 저장되어 있다면 이 노드의 인접 노드는 추가X
            continue
        for adj_node, adj_dist in adj_list[cur_node]:
            temp_dist = cur_dist + adj_dist
            if temp_dist < dist[adj_node]:
                dist[adj_node] = temp_dist
                heapq.heappush(q, [temp_dist, adj_node])


dijkstra(start)
print(dist[end])
```
<br/>

### ⭐️ 리뷰 Point
<!-- 이 PR에 대한 논의하고 싶은 사항이나 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


