### PR TITLE
250112 : [BOJ 5567] 결혼식 / S2

### DIFF
--- a/_eunjin/eunjin_5567.py
+++ b/_eunjin/eunjin_5567.py
@@ -1,0 +1,32 @@
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+
+N = int(input())
+M = int(input())
+
+adj_list = [[] for _ in range(N+1)]
+visited = [False] * (N+1)
+
+for _ in range(M):
+    a, b = map(int, input().split())
+    adj_list[a].append(b)
+    adj_list[b].append(a)
+
+q = deque()
+q.append([1, 0])  # node, depth
+visited[1] = True
+
+
+while q:
+    node, depth = q.popleft()
+
+    for adj_node in adj_list[node]:
+        if visited[adj_node]:
+            continue
+        if depth < 2:
+            q.append([adj_node, depth+1])
+            visited[adj_node] = True
+
+print(sum(visited)-1)


### PR DESCRIPTION
### 🚀 문제 번호
Resolve: {#350}  
<br/>

### 🔍 구현 방법
<!-- 문제를 해결한 구체적인 방법을 설명해주세요. -->
인접리스트를 만든 후, 각 노드마다 연결된 노드를 탐색하는데 친구+친구의 친구까지만 탐색해야하므로 depth 관리가 필요해서 bfs로 탐색했습니다. queue에 [node,depth] 형태로 저장한 후, depth가 2 이상이면 다음 노드를 탐색하지 않도록 했습니다.
```
import sys
from collections import deque
input = sys.stdin.readline


N = int(input())
M = int(input())

adj_list = [[] for _ in range(N+1)]
visited = [False] * (N+1)

for _ in range(M):
    a, b = map(int, input().split())
    adj_list[a].append(b)
    adj_list[b].append(a)

q = deque()
q.append([1, 0])  # node, depth
visited[1] = True


while q:
    node, depth = q.popleft()

    for adj_node in adj_list[node]:
        if visited[adj_node]:
            continue
        if depth < 2:
            q.append([adj_node, depth+1])
            visited[adj_node] = True

print(sum(visited)-1)
```
<br/>

### ⭐️ 리뷰 Point
<!-- 이 PR에 대한 논의하고 싶은 사항이나 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


