### PR TITLE
250124 : [BOJ 1967] 트리의 지름 / G4

### DIFF
--- a/_hyolim/1967_트리의지름.c++
+++ b/_hyolim/1967_트리의지름.c++
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <vector>
+using namespace std;
+
+int n;
+vector<pair<int,int>> tree[10002];
+bool visited[10002];
+int ans=0;
+int endP;
+
+void input(){
+	cin >> n;
+	for(int i=0;i<n-1;i++){
+		int p,c,w;
+		cin>>p>>c>>w;
+		tree[p].push_back({c,w});
+		tree[c].push_back({p,w});
+	}
+}
+
+
+void dfs(int node,int num){
+	visited[node]=1;
+	if(ans<num) {
+		ans=num;
+		endP=node;
+	}
+
+
+	for(int i=0;i<tree[node].size();i++){
+		// visited 확인
+		if(visited[tree[node][i].first]) continue;
+		dfs(tree[node][i].first,num+tree[node][i].second);
+	}
+}
+
+void solve(){
+	dfs(1,0);
+	ans=0;
+	for(int i=0;i<=n;i++){
+		visited[i]=false;
+	}
+	dfs(endP,0);
+	cout<<ans;
+
+}
+
+int main(){
+	input();
+	// printTree();
+	solve();
+	// output();
+}


### PR DESCRIPTION
### 🚀 문제 번호
Resolve: {#371}  
<br/>

### 🔍 구현 방법
<!-- 문제를 해결한 구체적인 방법을 설명해주세요. -->
지름을 구한다는 생각에 모든 정점에서 양쪽으로 뻗어있는 가장 큰 가중치 두 개를 합해서 비교하는 방식을 생각했었습니다. 값이 비정상적으로 나와서 찾아보니까 가장 깊은 곳을 찾고, 그 깊은 곳에서 또 깊은 곳을 찾으면 지름이 된다는 것을 알았습니다. 
원래는 인접 행렬로 구했는데, 메모리 초과가 발생해서 인접 리스트로 구현했습니다.

```
#include <iostream>
#include <vector>
using namespace std;

int n;
vector<pair<int,int>> tree[10002];
bool visited[10002];
int ans=0;
int endP;

void input(){
	cin >> n;
	for(int i=0;i<n-1;i++){
		int p,c,w;
		cin>>p>>c>>w;
		tree[p].push_back({c,w});
		tree[c].push_back({p,w});
	}
}


void dfs(int node,int num){
	visited[node]=1;
	if(ans<num) {
		ans=num;
		endP=node;
	}


	for(int i=0;i<tree[node].size();i++){
		// visited 확인
		if(visited[tree[node][i].first]) continue;
		dfs(tree[node][i].first,num+tree[node][i].second);
	}
}

void solve(){
	dfs(1,0);
	ans=0;
	for(int i=0;i<=n;i++){
		visited[i]=false;
	}
	dfs(endP,0);
	cout<<ans;

}

int main(){
	input();
	// printTree();
	solve();
	// output();
}
```
<br/>

### ⭐️ 리뷰 Point
<!-- 이 PR에 대한 논의하고 싶은 사항이나 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


