### PR TITLE
250124 : [BOJ 1261] 알고스팟 / G4

### DIFF
--- a/_eunjin/eunjin_1261.py
+++ b/_eunjin/eunjin_1261.py
@@ -1,0 +1,41 @@
+from collections import deque
+import sys
+input = sys.stdin.readline
+
+dy = [1, 0, -1, 0]
+dx = [0, -1, 0, 1]
+
+INF = 100000
+
+
+def bfs(y, x):
+    q = deque()
+    q.append((y, x, 0))
+
+    while q:
+        y, x, d = q.popleft()
+
+        if dist[y][x] < d:
+            continue
+
+        for i in range(4):
+            ny = y+dy[i]
+            nx = x+dx[i]
+            if 0 <= ny < N and 0 <= nx < M:
+                temp_d = d
+                if matrix[ny][nx] == 1:
+                    temp_d += 1
+                if temp_d < dist[ny][nx]:
+                    dist[ny][nx] = temp_d
+                    q.append((ny, nx, temp_d))
+
+
+M, N = map(int, input().split())
+matrix = [list(map(int, list(input().strip()))) for _ in range(N)]
+dist = [[INF]*M for _ in range(N)]
+
+dist[0][0] = 0
+
+bfs(0, 0)
+
+print(dist[N-1][M-1])


### PR DESCRIPTION
### 🚀 문제 번호
Resolve: {#377}  
<br/>

### 🔍 구현 방법
<!-- 문제를 해결한 구체적인 방법을 설명해주세요. -->
일반적인 bfs 탐색에다가 dist 배열을 추가로 관리하도록 했습니다. dist 배열에는 해당 좌표에 도달할때까지 벽을 부순 횟수를 저장했습니다. 그리고 인접 좌표를 방문할때, 해당 좌표에 벽이 있으면 d+1, 없으면 d 그대로를 queue에 저장했습니다. 그리고 매번 좌표 방문 여부를 결정할 때, dist 배열에 저장되어있는 값보다 현재 temp_d값이 작으면 해당 좌표를 방문하도록 했습니다.
```
from collections import deque
import sys
input = sys.stdin.readline

dy = [1, 0, -1, 0]
dx = [0, -1, 0, 1]

INF = 100000


def bfs(y, x):
    q = deque()
    q.append((y, x, 0))

    while q:
        y, x, d = q.popleft()

        if dist[y][x] < d:
            continue

        for i in range(4):
            ny = y+dy[i]
            nx = x+dx[i]
            if 0 <= ny < N and 0 <= nx < M:
                temp_d = d
                if matrix[ny][nx] == 1:
                    temp_d += 1
                if temp_d < dist[ny][nx]:
                    dist[ny][nx] = temp_d
                    q.append((ny, nx, temp_d))


M, N = map(int, input().split())
matrix = [list(map(int, list(input().strip()))) for _ in range(N)]
dist = [[INF]*M for _ in range(N)]

dist[0][0] = 0

bfs(0, 0)

print(dist[N-1][M-1])
```
<br/>

### ⭐️ 리뷰 Point
<!-- 이 PR에 대한 논의하고 싶은 사항이나 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


