### PR TITLE
250210 : [BOJ 4358] 생태학 / S2

### DIFF
--- a/_eunjin/eunjin_4358.py
+++ b/_eunjin/eunjin_4358.py
@@ -1,0 +1,22 @@
+import sys
+input = sys.stdin.readline
+
+_dict = {}
+total = 0
+arr = []
+
+while True:
+    current = input().strip()
+    if not current:
+        break
+
+    total += 1
+    if current in _dict:
+        _dict[current] += 1
+    else:
+        _dict[current] = 1
+        arr.append(current)
+
+arr.sort()
+for tree in arr:
+    print(tree, f"{100*_dict[tree]/total:.4f}")


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#438}

## 🧩 문제 해결

**시간 내 해결:** ❌

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 해시, 브루트포스
- 🔹 전체 입력에 대해 각 줄마다의 나무 종의 이름을 dict의 key로, 해당 나무 종의 나무 그루 수를 value로 두어 저장했습니다. arr에는 전체 나무 종의 종류를 저장했습니다. 입력을 모두 받은 후에는 arr을 이름 오름차순으로 정렬하고, 출력을 하면서 dict에서 (해당 나무 종의 그루 수/전체 나무 그루 수)*100을 소수점 넷째자리까지 출력하도록 했습니다.
- 처음에는 .4f 포맷팅을 이용하지 않고 출력했는데 계속 8%에서 실패했습니다... 보니까 100.0, 50.0같이 소수점 아래가 0인 경우에도 100.0000, 50.0000으로 무조건 넷째자리까지 출력이 되어야하는 것 같았습니다..

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(NlogN)`
- **이유:** 전체 입력에 대해 _dict와 arr 생성하는데에는 `O(N)`, arr을 정렬하는데에는 `O(NlogN)`, 출력하는데에는 `O(N)`

## 💻 구현 코드

```python
import sys
input = sys.stdin.readline

_dict = {}
total = 0
arr = []

while True:
    current = input().strip()
    if not current:
        break

    total += 1
    if current in _dict:
        _dict[current] += 1
    else:
        _dict[current] = 1
        arr.append(current)

arr.sort()
for tree in arr:
    print(tree, f"{100*_dict[tree]/total:.4f}")

```
