### PR TITLE
250210 : [BOJ 20301] 반전 요세푸스 / S3 

### DIFF
--- a/_eunjin/eunjin_20301.py
+++ b/_eunjin/eunjin_20301.py
@@ -1,0 +1,37 @@
+N, K, M = map(int, input().split())
+
+queue = list(i for i in range(1, N+1))
+
+idx = K-1
+direction = False
+pop_num = 0
+
+# 1 2 3 4 5 6 7
+# 1 2 3 4 5 6, idx:6
+# 1 2 3 4 5, idx:5
+# 1 2 3 5, idx:3
+
+
+while True:
+    print(queue.pop(idx))
+    if not queue:  # 모든 사람을 제거한 경우
+        break
+
+    pop_num += 1
+
+    if pop_num == M:
+        direction = not direction
+        pop_num = 0
+
+    if direction:  # 왼쪽 방향
+        temp_idx = idx-K
+        if temp_idx < 0:
+            temp_idx = temp_idx % len(queue)
+        idx = temp_idx
+    else:  # 오른쪽 방향
+        temp_idx = idx+K-1
+        if temp_idx >= len(queue):
+            temp_idx = temp_idx % len(queue)
+        idx = temp_idx
+
+    # print(queue, ", next idx:", idx, ", dir:", direction)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#439}

## 🧩 문제 해결

**시간 내 해결:**  ❌

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 덱
- 🔹 1~N까지의 값을 queue에 넣어 놓고, 조건에 맞는 idx에 해당하는 값을 하나씩 빼면서 queue가 비어있을 때까지 진행했습니다. pop_num으로 제거된 사람의 수를 저장하고, pop_num==M이 될때마다 direction을 반대로 바꿔주었습니다. direction에 따라 다음 인덱스를 다르게 계산했고, 원을 이루는 것을 감안해서 % 연산으로 다음 인덱스를 계산해 idx를 업데이트 했습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N^2)`
- **이유:** 전체 루프를 도는 연산 `O(N)` * queue.pop(idx)로 특정 인덱스의 요소를 제거하는 연산 `O(N)` = `O(N^2)`

## 💻 구현 코드

```python
N, K, M = map(int, input().split())

queue = list(i for i in range(1, N+1))

idx = K-1
direction = False
pop_num = 0

while True:
    print(queue.pop(idx))
    if not queue:  # 모든 사람을 제거한 경우
        break

    pop_num += 1

    if pop_num == M:
        direction = not direction
        pop_num = 0

    if direction:  # 왼쪽 방향
        temp_idx = idx-K
        if temp_idx < 0:
            temp_idx = temp_idx % len(queue)
        idx = temp_idx
    else:  # 오른쪽 방향
        temp_idx = idx+K-1
        if temp_idx >= len(queue):
            temp_idx = temp_idx % len(queue)
        idx = temp_idx
```

찾아보니까 파이썬 deque를 이용하면 아예 인덱스 계산도 간편해지고 popleft()를 이용할 수 있어서 `O(N)`으로 해결이 가능하다고 하네요..!
```python
from collections import deque

# 입력 처리
N, K, M = map(int, input().split())

# 1부터 N까지의 숫자를 포함하는 deque 생성
queue = deque(range(1, N + 1))

# 초기 설정
direction = False  # False: 오른쪽 방향 (기본), True: 왼쪽 방향
pop_num = 0  # 제거된 개수 카운트

# 메인 로직
while queue:
    if direction:  # 왼쪽 방향일 때 (반대 방향)
        queue.rotate(K)  # K번 왼쪽으로 이동 (deque의 오른쪽으로 회전)
    else:  # 오른쪽 방향일 때
        queue.rotate(-(K - 1))  # (K-1)번 오른쪽으로 이동 (deque의 왼쪽으로 회전)

    print(queue.popleft())  # 가장 앞의 원소 제거

    pop_num += 1  # 제거된 개수 증가

    if pop_num == M:  # M번 제거될 때마다 방향 전환
        direction = not direction
        pop_num = 0
```
