### PR TITLE
250324 : [BOJ 11441] 합 구하기

### DIFF
--- a/_sungyoon/11441.cpp
+++ b/_sungyoon/11441.cpp
@@ -1,0 +1,43 @@
+#include <bits/stdc++.h>
+using namespace std;
+typedef pair<int, int> pii;
+typedef long long ll;
+#define endl "\n"
+
+int dx[] = {-1, 1, 0, 0};
+int dy[] = {0, 0, -1, 1};
+int N, M;
+int arr[100001];
+int dp[100001];
+
+void accumulate() {
+    for(int i = 1; i <= N; i++) {
+        dp[i] = dp[i-1] + arr[i];
+    }
+}
+
+void input() {
+    cin >> N;
+
+    for(int i = 1; i <= N; i++) {
+        cin >> arr[i];
+    }
+
+    accumulate();
+
+    cin >> M;
+
+    for(int i = 0; i < M; i++) {
+        int a, b;
+        cin >> a >> b;
+        cout << dp[b] - dp[a] + arr[a] << endl;
+    }
+}
+
+int main() {
+    ios::sync_with_stdio(0);
+    cin.tie(0), cout.tie(0);
+
+    input();
+}
+


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#686}

## 🧩 문제 해결

**시간 내 해결:** ✅  8m

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** 누적합 알고리즘 사용
- 🔹 **어떤 방식으로 접근했는지**  N의 범위와 M의 범위의 최대가 100,000 이므로 결국 2중 for문을 사용할 경우 10^10 이 나오므로 시간초과가난다 즉 O(N)의 방식인 누적합을 사용하여 시간초과가 안나게 하였다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N)`
- **이유:**  누적합 구하는 구간에서 O(N) 만큼 시간이 들기 때문이다.

## 💻 구현 코드

```c++
# 여기에 구현 코드를 작성하세요.
#include <bits/stdc++.h>
using namespace std;
typedef pair<int, int> pii;
typedef long long ll;
#define endl "\n"

int dx[] = {-1, 1, 0, 0};
int dy[] = {0, 0, -1, 1};
int N, M;
int arr[100001];        // 입력 배열
int dp[100001];        // 누적합 배열

void accumulate() {              // 누적합 구하는 함수
    for(int i = 1; i <= N; i++) {
        dp[i] = dp[i-1] + arr[i];       
    }
}

void input() {
    cin >> N;

    for(int i = 1; i <= N; i++) {
        cin >> arr[i];
    }

    accumulate();

    cin >> M;

    for(int i = 0; i < M; i++) {          // b까지 누적합 한 부분에서 a까지 누적합한 부분을 뺀 이후 a좌표를 더해준다. 
        int a, b;
        cin >> a >> b;
        cout << dp[b] - dp[a] + arr[a] << endl;
    }
}

int main() {
    ios::sync_with_stdio(0);
    cin.tie(0), cout.tie(0);

    input();
}

```
