### PR TITLE
250402 : ⭐️ [BOJ 17406] 배열 돌리기 4

### DIFF
--- a/_gilljong/17406.py
+++ b/_gilljong/17406.py
@@ -1,0 +1,43 @@
+from sys import stdin as s
+from itertools import permutations
+from copy import deepcopy
+s = open("txt/17406.txt", "r")
+
+N,M,K = map(int,s.readline().split())
+
+grid = [[0] * (M+1)]
+
+for _ in range(N):
+    grid.append([0] + list(map(int, s.readline().split())))
+
+turn = [list(map(int, s.readline().split())) for _ in range(K)]
+
+min_value = 999999
+def trun_grid(new_grid, order): # 회전 + 배열 최솟 값 구하기
+    global min_value
+    for k in range(len(order)): # 순열 !
+        tmp_grid = deepcopy(new_grid)
+
+        start = (order[k][0] - order[k][2], order[k][1] - order[k][2])
+        end = (order[k][0] + order[k][2], order[k][1] + order[k][2])
+
+        size = end[0] - start[0] + 1
+
+        for i in range(size,1,-2):
+            for j in range(1, i):
+                new_grid[start[0] + j - 1][start[1]] = tmp_grid[start[0] + j][start[1]]
+                new_grid[start[0]][start[1]+j] = tmp_grid[start[0]][start[1]+j-1]
+                new_grid[start[0]+j][start[1]+i-1] = tmp_grid[start[0] + j -1][start[1]+i-1]
+                new_grid[start[0]+i-1][start[1]+j-1] = tmp_grid[start[0] + i - 1][start[1]+j]
+            start = (start[0] + 1, start[1] + 1)
+
+    for i in range(1,N+1): # 최솟 값 계산
+        min_value = min(min_value,sum(new_grid[i]))
+
+for q in permutations(turn):
+    new_grid = deepcopy(grid)
+    trun_grid(new_grid, q)
+
+print(min_value)
+
+# 57m 27s


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#743}

## 🧩 문제 해결

**시간 내 해결:** ❌

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** 회전행렬, 순열
- 🔹 **어떤 방식으로 접근했는지** 회의에서 얘기했던 대로 구현했고, 최종적으로 최솟값을 찾는 로직에서 행 열을 헷갈려서 오래걸렸습니다. ㅠㅠ

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N!)`
- **이유:** 순열로 접근

## 💻 구현 코드

```
from sys import stdin as s
from itertools import permutations
from copy import deepcopy
s = open("txt/17406.txt", "r")

N,M,K = map(int,s.readline().split())

grid = [[0] * (M+1)]

for _ in range(N):
    grid.append([0] + list(map(int, s.readline().split())))

turn = [list(map(int, s.readline().split())) for _ in range(K)]

min_value = 999999
def trun_grid(new_grid, order): # 회전 + 배열 최솟 값 구하기
    global min_value
    for k in range(len(order)): # 순열 !
        tmp_grid = deepcopy(new_grid)

        start = (order[k][0] - order[k][2], order[k][1] - order[k][2])
        end = (order[k][0] + order[k][2], order[k][1] + order[k][2])

        size = end[0] - start[0] + 1

        for i in range(size,1,-2):
            for j in range(1, i):
                new_grid[start[0] + j - 1][start[1]] = tmp_grid[start[0] + j][start[1]]
                new_grid[start[0]][start[1]+j] = tmp_grid[start[0]][start[1]+j-1]
                new_grid[start[0]+j][start[1]+i-1] = tmp_grid[start[0] + j -1][start[1]+i-1]
                new_grid[start[0]+i-1][start[1]+j-1] = tmp_grid[start[0] + i - 1][start[1]+j]
            start = (start[0] + 1, start[1] + 1)

    for i in range(1,N+1): # 최솟 값 계산
        min_value = min(min_value,sum(new_grid[i]))

for q in permutations(turn):
    new_grid = deepcopy(grid)
    trun_grid(new_grid, q)

print(min_value)


# 57m 27s

```
