### PR TITLE
⭐️ 250407 : [BOJ 2212] 센서

### DIFF
--- a/_gilljong/2212.py
+++ b/_gilljong/2212.py
@@ -1,0 +1,35 @@
+from sys import stdin as s
+
+s = open("txt/2212.txt","r")
+
+N = int(s.readline())
+K = int(s.readline())
+sensors = list(map(int,s.readline().split()))
+
+sensors.sort()
+sub = [(0,0)]
+for i in range(1,N):
+    sub.append((i,sensors[i]-sensors[i-1]))
+
+sub.sort(key = lambda x : -x[1])
+cut = sub[0:K-1] # K보다 작은 수로 컷
+cut.sort(key = lambda x : x[0])
+
+print(cut)
+result = 0
+last_center = 0
+for i in range(len(cut)):
+    unit = sensors[last_center:cut[i][0]]
+    print(unit)
+    if len(unit) <= 1: # 길이가 0이라면 수신가능영역 0
+        pass
+    else:
+        result += (unit[-1] - unit[0])
+#   print(sensors[last_center:cut[i][0]])
+    last_center = cut[i][0]
+
+unit = sensors[last_center:]
+
+result += (unit[-1] - unit[0])
+print(result)
+# 54m 43s


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#781}

## 🧩 문제 해결

**시간 내 해결:** ✅ 53m 43s

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** 정렬, 구현
- 🔹 **어떤 방식으로 접근했는지** K개의 기지국을 두기 위해 리스트를 K-1로 자른다는 생각을 했습니다.
자르는 기준은 센서 정렬 후, 센서 간의 거리가 가장 긴 곳을 K-1만큼 자릅니다.
이후 슬라이싱으로 단위 송신기 세트를 구해준 뒤, 단일 송신기라면 0으로 예외처리 해주고, 나머지는 센서의 길이를 더해줍니다.

+ 엣지케이스
10
5
1 1 1 1 1 1 1 1 1 1

정답 ->  0

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(nlogn)`
- **이유:** 정렬

## 💻 구현 코드

```
from sys import stdin as s

s = open("txt/2212.txt","r")

N = int(s.readline())
K = int(s.readline())
sensors = list(map(int,s.readline().split()))

sensors.sort() # 정렬
sub = [(0,0)]
for i in range(1,N): # 센서간의 차이를 계산 후 리스트에 추가
    sub.append((i,sensors[i]-sensors[i-1]))

sub.sort(key = lambda x : -x[1]) # 센서의 차이 중 거리가 긴 순으로 재정렬
cut = sub[0:K-1] # K-1 까지 자르기 위해 리스트 잘라주기
cut.sort(key = lambda x : x[0]) # 다시 인덱스 기준으로 정렬(sensors 접근에 용이하게)

result = 0
last_center = 0 # 마지막 기지국
for i in range(len(cut)):
    unit = sensors[last_center:cut[i][0]] # 잘라진 송신기들
    if len(unit) <= 1: # 송신기의 길이가 0 보다 작다면 수신가능영역 0 예외처리
        pass
    else:
        result += (unit[-1] - unit[0]) # 센서의 길이를 더해줌
#   print(sensors[last_center:cut[i][0]])
    last_center = cut[i][0]

unit = sensors[last_center:]

result += (unit[-1] - unit[0])
print(result)
# 54m 43s

```
