### PR TITLE
⭐️ 250410 : [BOJ 11000] 강의실 배정

### DIFF
--- a/_hyolim/11000_강의실배정.c++
+++ b/_hyolim/11000_강의실배정.c++
@@ -1,0 +1,34 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <queue>
+
+using namespace std;
+
+int n;
+vector<pair<int, int>> classes;
+
+int main() {
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+
+    cin >> n;
+    for (int i = 0; i < n; i++) {
+        int s, t;
+        cin >> s >> t;
+        classes.push_back({s, t});
+    }
+
+    sort(classes.begin(), classes.end());
+
+    priority_queue<int, vector<int>, greater<int>> pq;
+
+    for (auto [s, t] : classes) {
+        if (!pq.empty() && pq.top() <= s) {
+            pq.pop(); 
+        }
+        pq.push(t);
+    }
+
+    cout << pq.size(); 
+}


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#817}

## 🧩 문제 해결

**시간 내 해결:** ❌ 36M 25S (답확인)

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** 그리디, 우선순위큐, 정렬
- 🔹 **어떤 방식으로 접근했는지** 처음에는 끝나는 시간을 내림차순 기준으로 정렬해놓고 그 배열을 돌면서 시작시간이 내림차순으로 되어있는 Set 자료형에 넣었습니다. 38%에서 틀려서 확인하다가 set이 중복을 허용하지 않는다는 사실을 깨닫고, Priority queue로 바꿨습니다. 그런데, Priority queue로 바꾸니까 우선순위 큐 내에서 정렬이 원하지 않는대로 됐습니다. 시작시간 기준 내림차순을 해야하는데 오름차순으로 출력됐습니다.
그 이유가 우선순위큐는 가장 큰 값이 나오도록하는 max-heap 구조라서, operator<인데 return st>o.st를 할 경우 `st>o.st가 true 인 경우 == st가 더 큰 경우`가 우선순위 큐 입장에서 더 작은 원소라고 판단한다. 따라서 st가 더 큰 경우가 작은 것으로 판단돼서, 오름차순으로 정렬된다. 
결론 : Priority Queue를 사용할 때는 구조체보다는 cmp를 만들어서 사용하자..

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(NlogN)`
- **이유:**

## 💻 구현 코드

```
#include <iostream>
#include <algorithm>
#include <vector>
#include <queue>

using namespace std;

int n;
vector<pair<int, int>> classes;

int main() {
    ios_base::sync_with_stdio(0);
    cin.tie(0);

    cin >> n;
    for (int i = 0; i < n; i++) {
        int s, t;
        cin >> s >> t;
        classes.push_back({s, t});
    }

    // 시작 시간 기준 오름차순 정렬
    sort(classes.begin(), classes.end());

    // 끝나는 시간 기준으로 우선순위 큐
    priority_queue<int, vector<int>, greater<int>> pq;

    for (auto [s, t] : classes) {
        if (!pq.empty() && pq.top() <= s) {
            pq.pop(); // 회의실 재사용 가능
        }
        pq.push(t); // 새 수업 할당
    }

    cout << pq.size(); // 필요한 강의실 수
}

```
