### PR TITLE
⭐️ 250417 : [BOJ 2210] 숫자판 점프

### DIFF
--- a/_eunjin/2210_숫자판_점프.py
+++ b/_eunjin/2210_숫자판_점프.py
@@ -1,0 +1,28 @@
+matrix = [list(input().split()) for _ in range(5)]
+
+# dfs로 이동하면서 depth가 5되면 종료
+# set에 담기
+
+dy = [1, 0, -1, 0]
+dx = [0, 1, 0, -1]
+
+answer = set()
+
+def dfs(y, x, string):
+    if len(string) == 6:
+        answer.add(string)
+        return
+
+    for i in range(4):
+        ny, nx = y + dy[i], x + dx[i]
+        if 0 <= ny < 5 and 0 <= nx < 5:
+            new = string + matrix[ny][nx]
+            dfs(ny, nx, new)
+
+
+for y in range(5):
+    for x in range(5):
+        dfs(y, x, matrix[y][x])
+
+
+print(len(answer))


### PR DESCRIPTION
8M

## 🚀 이슈 번호

**Resolve:** {#869}

## 🧩 문제 해결

**시간 내 해결:** ✅ 8M

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** dfs
- 🔹 **어떤 방식으로 접근했는지** 이동 가능한 횟수가 5번(총 숫자 길이가 6)으로 제한되어 있기 때문에 dfs를 선택했습니다. 배열의 각 숫자를 그냥 문자로 취급해서 dfs 파라미터로 넘겨주고, 해당 문자의 길이가 6이 되면 set에 추가했습니다. 마지막에 set의 길이를 출력했습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(5*5*4^5)`
- **이유:**

## 💻 구현 코드

```python
matrix = [list(input().split()) for _ in range(5)]

# dfs로 이동하면서 depth가 5되면 종료
# set에 담기

dy = [1, 0, -1, 0]
dx = [0, 1, 0, -1]

answer = set()

def dfs(y, x, string):
    if len(string) == 6:
        answer.add(string)
        return

    for i in range(4):
        ny, nx = y + dy[i], x + dx[i]
        if 0 <= ny < 5 and 0 <= nx < 5:
            new = string + matrix[ny][nx]
            dfs(ny, nx, new)


for y in range(5):
    for x in range(5):
        dfs(y, x, matrix[y][x])


print(len(answer))

```
