### PR TITLE
⭐️ 250417 : [BOJ 2210] 숫자판 점프

### DIFF
--- a/_youn/boj_2210.py
+++ b/_youn/boj_2210.py
@@ -1,0 +1,41 @@
+from collections import deque
+
+def bfs(start, numbers):
+    global values
+    queue = deque([(start[0], start[1], numbers[start[0]][start[1]])])
+
+    while queue:
+        x, y, val = queue.popleft()
+
+        if len(val)==6:
+            values.add(val)
+            continue
+        
+        for dx, dy in [(0, 1), (1, 0), (0, -1), (-1, 0)]:
+            nx, ny = x+dx, y+dy
+            if 0<=nx<5 and 0<=ny<5:
+                queue.append((nx, ny, val+numbers[nx][ny]))
+
+def dfs(start, numbers):
+    stack = [(start[0], start[1], numbers[start[0]][start[1]])]
+
+    while stack:
+        x, y, val = stack.pop()
+
+        if len(val)==6:
+            values.add(val)
+            continue
+        
+        for dx, dy in [(0, 1), (1, 0), (0, -1), (-1, 0)]:
+            nx, ny = x+dx, y+dy
+            if 0<=nx<5 and 0<=ny<5:
+                stack.append((nx, ny, val+numbers[nx][ny]))
+
+numbers = [list(input().split()) for _ in range(5)]
+values = set()
+
+for i in range(5):
+    for j in range(5):
+        # bfs((i,j),numbers)
+        dfs((i, j), numbers)
+print(len(values))


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#869}

## 🧩 문제 해결

**시간 내 해결:** ✅ 30m

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** bfs, dfs
- 🔹 **어떤 방식으로 접근했는지** 중복 탐색을 허용하는 bfs /dfs 알고리즘을 사용하여 풀이했습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(H*W*(N+E))`
- **이유:** bfs 알고리즘으로 풀이했을 경우, 가로 길이 W 세로 길이 H 그리고 bfs 알고리즘의 시간 복잡도 O(N+E)를 곱하여 구했습니다. 다만 이 문제의 경우 H와 W가 5로 제한되어 있기 때문에 실제로는 O(N+E)에 가까운 시간 복잡도를 보입니다. 

## 💻 구현 코드

```Python
from collections import deque

def bfs(start, numbers):
    global values
    queue = deque([(start[0], start[1], numbers[start[0]][start[1]])])

    while queue:
        x, y, val = queue.popleft()

        if len(val)==6:
            values.add(val)
            continue
        
        for dx, dy in [(0, 1), (1, 0), (0, -1), (-1, 0)]:
            nx, ny = x+dx, y+dy
            if 0<=nx<5 and 0<=ny<5:
                queue.append((nx, ny, val+numbers[nx][ny]))

def dfs(start, numbers):
    stack = [(start[0], start[1], numbers[start[0]][start[1]])]

    while stack:
        x, y, val = stack.pop()

        if len(val)==6:
            values.add(val)
            continue
        
        for dx, dy in [(0, 1), (1, 0), (0, -1), (-1, 0)]:
            nx, ny = x+dx, y+dy
            if 0<=nx<5 and 0<=ny<5:
                stack.append((nx, ny, val+numbers[nx][ny]))

numbers = [list(input().split()) for _ in range(5)]
values = set()

for i in range(5):
    for j in range(5):
         bfs((i,j),numbers)
        # dfs((i, j), numbers)
print(len(values))

```
