### PR TITLE
⭐️ 250418 : [BOJ 17281] ⚾

### DIFF
--- a/_youn/boj_17281.py
+++ b/_youn/boj_17281.py
@@ -1,0 +1,32 @@
+from itertools import permutations
+
+def simulate(order):
+    score = 0
+    batter_idx = 0
+    for inning in innings:
+        out = 0
+        base = [0, 0, 0]
+        while out<3:
+            in_idx = order[batter_idx]
+            result = inning[in_idx]
+
+            if result == 0: # 아웃
+                out+=1
+            elif result == 4: # 홈런
+                score += sum(base) + 1
+                base = [0, 0, 0]
+            else: # 안타, 2루타, 3루타
+                base = [0] * (result-1) + [1] + base
+                score += sum(base[3:])
+                base = base[:3]
+
+            batter_idx = (batter_idx + 1) % 9
+    return score
+
+N = int(input())
+innings = [list(map(int, input().split())) for _ in range(N)]
+score = 0
+for p in permutations(range(1,9)): # 타순
+    order = list(p[:3]) + [0] + list(p[3:])
+    score = max(score, simulate(order))
+print(score)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#879}

## 🧩 문제 해결

**시간 내 해결:** ❌

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** 브루트포스
- 🔹 **어떤 방식으로 접근했는지** 
- 타순을 순열로 정한 뒤, 전체 경기를 시뮬레이션하는 코드를 작성했습니다.
- simulate 함수에서는 N번의 이닝동안 아웃, 홈런, 안타, 2루타, 3루타에서의 점수와 선수들이 몇 번 base에 있는지 상황을 갱신해줍니다.
- 이와 같은 동작을 타순 순열 개수만큼 반복하며 얻을 수 있는 점수의 최댓값을 구합니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N!*N)`
- **이유:** 순열에 대한 시간복잡도 N!와 이닝 횟수에 대한 시간복잡도 N을 곱하였습니다. 다만 백준에서 문제 풀이 시, pyp3으로 설정하여도 ‘시간 초과’가 발생하여서 어떤 부분을 최적화해줘야 할지 고민입니다..

## 💻 구현 코드

```Python
from itertools import permutations

def simulate(order):
    score = 0
    batter_idx = 0
    for inning in innings:
        out = 0
        base = [0, 0, 0]
        while out<3:
            in_idx = order[batter_idx]
            result = inning[in_idx]

            if result == 0: # 아웃
                out+=1
            elif result == 4: # 홈런
                score += sum(base) + 1
                base = [0, 0, 0]
            else: # 안타, 2루타, 3루타
                base = [0] * (result-1) + [1] + base
                score += sum(base[3:])
                base = base[:3]

            batter_idx = (batter_idx + 1) % 9
    return score

N = int(input())
innings = [list(map(int, input().split())) for _ in range(N)]
score = 0
for p in permutations(range(1,9)): # 타순
    order = list(p[:3]) + [0] + list(p[3:])
    score = max(score, simulate(order))
print(score)
```
