### PR TITLE
⭐️ 250421 : [BOJ 20164] 홀수 홀릭 호석

### DIFF
--- a/_youn/boj_20164..py
+++ b/_youn/boj_20164..py
@@ -1,0 +1,24 @@
+from itertools import combinations
+
+def oddNum(N):
+    odds = list(filter(lambda x: int(x)%2==1, list(N)))
+    return len(odds)
+
+def solve(N, count):
+    if len(N)==1:
+        global ans
+        ans.append(count)
+        return
+    elif len(N)==2:
+        val = str(int(N[0]) + int(N[1]))
+        solve(val, count + oddNum(val))
+    else:
+        for c in combinations(range(1, len(N)), 2):
+            i, j = c
+            val = str(int(N[:i]) + int(N[i:j]) + int(N[j:]))
+            solve(val, count + oddNum(val))
+
+N = input()
+ans = []
+solve(N, oddNum(N))
+print(min(ans), max(ans))


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#890}

## 🧩 문제 해결

**시간 내 해결:** ✅ 1h

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** 브루트포스, 재귀
- 🔹 **어떤 방식으로 접근했는지**
- 문자열 `N`의 길이가 3 이상인 경우 조합을 사용하여 구간을 나눈 뒤, 그 합을 구했습니다. 구한 합에서 홀수 개수를 `count`에 더하여 재귀함수의 파라미터로 전달합니다.
- 문자열 `N`의 길이가 2인 경우, 마찬가지로 첫번째 숫자와 두번째 숫자를 합한 뒤, 구한 합에서 홀수 개수를 `count`에 더하여 재귀함수의 파라미터로 전달합니다.
- 문자열 N의 길이가 1인 경우 재귀를 종료하고, `ans`에 `count` 값을 append한 뒤 `ans`에 있는 min max 값을 통해 답을 도출하는 방식으로 구현했습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N^3)`
- **이유:** 최대자리수만큼 반복하므로 시간복잡도 O(N)과 조합을 구할 때 시간복잡도 O(N(N-1)/2)을 곱했습니다.

## 💻 구현 코드

```Python
from itertools import combinations

def oddNum(N):
    odds = list(filter(lambda x: int(x)%2==1, list(N)))
    return len(odds)

def solve(N, count):
    if len(N)==1:
        global ans
        ans.append(count)
        return
    elif len(N)==2:
        val = str(int(N[0]) + int(N[1]))
        solve(val, count + oddNum(val))
    else:
        for c in combinations(range(1, len(N)), 2):
            i, j = c
            val = str(int(N[:i]) + int(N[i:j]) + int(N[j:]))
            solve(val, count + oddNum(val))

N = input()
ans = []
solve(N, oddNum(N))
print(min(ans), max(ans))

```
