### PR TITLE
250429 : [BOJ 16198] 에너지 모으기

### DIFF
--- a/_youn/boj_16198.py
+++ b/_youn/boj_16198.py
@@ -1,0 +1,16 @@
+def solve(N, W, val):
+    if len(W) == 2:
+        global ans
+        ans = max(ans, val)
+        return
+
+    for idx in range(1, N-1):
+        tmpW = W[:idx] + W[idx+1:]
+        solve(N-1, tmpW, val+W[idx-1]*W[idx+1])
+        
+N = int(input())
+W = list(map(int, input().split()))
+ans = 0
+
+solve(N, W, 0)
+print(ans)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#961}

## 🧩 문제 해결

**스스로 해결:** ✅ 30m

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** `브루트포스`, `백트래킹`
- 🔹 **어떤 방식으로 접근했는지**
- 에너지 구슬의 선택 순서에 따라서 최종 값이 바뀌는 것을 알 수 있습니다.
- N은 최대 10이며 첫번째와 마지막 구슬은 선택할 수 없으므로 전체 경우의 수를 고려했을 때 브루트포스를 하더라도 최대 8!입니다.
- 초반에 백트래킹이 아닌 순열로 인덱스 순열들을 만들어 전체 경우의 수를 고려하려고 했으나, W에서 x번째 구슬을 제거했을 경우 리스트의 인덱스가 다시 바뀌게 됩니다. 따라서 순열보다 백트래킹으로 해결하는 것이 더 적절하다고 판단되었습니다.
- 백트래킹으로 x번째 구슬을 선택하여 이를 제거한 배열을 인자로 전달하여 에너지 구슬의 합을 계산하는 solve 함수를 통해 최댓값을 구했습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N!)`
- **이유:** 전체 경우의 수를 고려하기 때문입니다.

## 💻 구현 코드

백트래킹으로 해결한 저의 풀이입니다.

``` Python
def solve(N, W, val):
    if len(W) == 2:
        global ans
        ans = max(ans, val)
        return

    for idx in range(1, N-1):
        tmpW = W[:idx] + W[idx+1:]
        solve(N-1, tmpW, val+W[idx-1]*W[idx+1])
        
N = int(input())
W = list(map(int, input().split()))
ans = 0

solve(N, W, 0)
print(ans)

```

백준 살펴보니 left와 right 변수를 통해 dp로 해결한 풀이 방식도 있었습니다.

``` Python
import sys
input = lambda: sys.stdin.readline().rstrip()

N = int(input())
weights = list(map(int, input().split()))
dp = [[0 for _ in range(N)] for _ in range(N)]

for length in range(3, N + 1):
    for left in range(N - length + 1):
        right = left + length - 1
        for mid in range(left + 1, right):
            energy = weights[left] * weights[right]
            energy += dp[left][mid] + dp[mid][right]
            dp[left][right] = max(dp[left][right], energy)
print(dp[0][N-1])

```