### PR TITLE
250430 : [BOJ 2866] 문자열 잘라내기

### DIFF
--- a/_youn/boj_2866.py
+++ b/_youn/boj_2866.py
@@ -1,0 +1,23 @@
+def can_remove_row(k, R, C, strings):
+    seen = set()
+    for j in range(C):
+        word = ''.join(strings[i][j] for i in range(k, R))
+        if word in seen:
+            return False
+        seen.add(word)
+    return True
+
+def solve(R, C, strings):
+    left, right, ans = 0, R - 1, 0
+    while left <= right:
+        mid = (left + right) // 2
+        if can_remove_row(mid, R, C, strings):
+            ans = mid
+            left = mid + 1
+        else:
+            right = mid - 1
+    return ans
+
+R, C = list(map(int, input().split()))
+strings = [input() for _ in range(R)]
+print(solve(R, C, strings))


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#972}

## 🧩 문제 해결

**스스로 해결:** ❌

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** `이분탐색`
- 🔹 **어떤 방식으로 접근했는지**
- 초기 풀이할 때 defaultdict에 문자열의 개수를 저장하여 1이상일 경우 count를 반환하는 방식으로 코딩했으나 시간 초과가 발생했습니다.
- 알고리즘을 확인해 보니 이분탐색 문제였고, 다음과 같이 풀이했습니다:
    - 이분 탐색 while 루프 돌면서 `mid` 행 수만큼 윗줄을 삭제한 후, 열 단위로 세로 문자열 추출했으며, 해당 문자열이 set()에 있는지를 검사했습니다.
    - 중복된 문자열이 없다면 `left`를 1 증가시키고, 있다면 `right`를 1 감소시킵니다.
    - `left`는 정답 후보의 하한선이며, `right`는 정답 후보의 상한선, `mid`는 현재 실험 대상입니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(C * R * log R)`
- **이유:** can_remove_row 함수의 시간 복잡도 `O(C * R)` 와 이분 탐색할 때의 시간 복잡도 `O(log R)` 의 곱입니다.

## 💻 구현 코드

초기 딕셔너리로 구현한 코드입니다.
```Python
from collections import defaultdict

def solve(R, C, strings):
    count, start = -1, 0
    while start < R:
        d = defaultdict(int)
        for j in range(C):
            word = ''.join(strings[i][j] for i in range(start, R))
            if d[word]>0:
                return count
            d[word]+=1
        count += 1
        start += 1
    return count

R, C = list(map(int, input().split()))
strings = [input() for _ in range(R)]
print(solve(R, C, strings))

```

이분탐색한 코드입니다.

```Python
def can_remove_row(k, R, C, strings):
    seen = set()
    for j in range(C):
        word = ''.join(strings[i][j] for i in range(k, R))
        if word in seen:
            return False
        seen.add(word)
    return True

def solve(R, C, strings):
    left, right, ans = 0, R - 1, 0
    while left <= right:
        mid = (left + right) // 2
        if can_remove_row(mid, R, C, strings):
            ans = mid
            left = mid + 1
        else:
            right = mid - 1
    return ans

R, C = list(map(int, input().split()))
strings = [input() for _ in range(R)]
print(solve(R, C, strings))
```