### PR TITLE
250507 : [BOJ 24480] 알고리즘 수업 - 깊이 우선 탐색 2

### DIFF
--- a/_youn/boj_24480.py
+++ b/_youn/boj_24480.py
@@ -1,0 +1,32 @@
+from collections import defaultdict, deque
+
+def dfs(E:defaultdict, R:int, N:int):
+    stack = deque([R])
+    visited = [False for _ in range(N+1)]
+    visited[R] = True
+    order = [0 for _ in range(N+1)]
+    cnt = 1
+
+    while stack:
+        u = stack.pop()
+        visited[u] = True
+        if order[u]==0:
+            order[u] = cnt
+            cnt += 1
+
+        for v in E[u]:
+            if not visited[v]:
+                stack.append(v)
+    return order[1:]          
+
+# Input
+N, M, R = list(map(int, input().split()))
+E = defaultdict(list)
+for _ in range(M):
+    u, v = map(int, input().split())
+    E[u].append(v)
+    E[v].append(u)
+
+for k in E.keys():
+    E[k].sort()
+print(*dfs(E, R, N),sep='\n')


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1000}

## 🧩 문제 해결

**스스로 해결:** ✅ 50m

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지**  `dfs`
- 🔹 **어떤 방식으로 접근했는지** 
- 방문한 순서를 출력하는 문제였는데, 방문한 값을 출력하는 문제로 혼동하여 문제 풀이 시 시간이 예상보다 더 소요되었습니다. recurssion limit이 걸려있어 `재귀`가 아닌 `스택`으로 문제 풀이했습니다. 문제 자체는 어렵지 않았으나 자료구조로 해결하려다 보니 조금 까다롭게 느껴졌습니다.
- `E` 딕셔너리에 연결된 노드들을 모두 저장한 뒤, 이를 오름차순 정렬해주었습니다. 오름차순 정렬한 이유는 그래프에서 특정 노드와 연결된 다른 노드들을 꺼낼 때 맨 마지막에 가장 큰 값을 지닌 노드가 오게 만들기 위함입니다.
- 그 후, dfs 함수에서`order` 리스트를 통해 방문한 순서를 기록한 뒤 출력합니다. 이때 방문한 적이 있는 노드라면, 즉 `order[u]`가 0이 아닌 경우, 방문순서를 기록하고 방문순서 인덱스 cnt를 1 증가시켜줍니다. 또한, 실제로 방문한 노드들에 대해서만 `visited`를 True로 설정합니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N^2)`
- **이유:**
- E 딕셔너리의 키 값에 대해서 정렬할 때 시간복잡도는 `O(N^2)`입니다.
- dfs 알고리즘의 시간복잡도는 `O(V+E)`로, V는 최대 10만, E는 최대 20만이므로 최대 30만 정도의 시간복잡도를 갖습니다.
- 
## 💻 구현 코드

```Python
from collections import defaultdict, deque

def dfs(E:defaultdict, R:int, N:int):
    stack = deque([R])
    visited = [False for _ in range(N+1)]
    visited[R] = True
    order = [0 for _ in range(N+1)]
    cnt = 1

    while stack:
        u = stack.pop()
        visited[u] = True
        if order[u]==0:
            order[u] = cnt
            cnt += 1

        for v in E[u]:
            if not visited[v]:
                stack.append(v)
    return order[1:]          

# Input
N, M, R = list(map(int, input().split()))
E = defaultdict(list)
for _ in range(M):
    u, v = map(int, input().split())
    E[u].append(v)
    E[v].append(u)

for k in E.keys():
    E[k].sort()
print(*dfs(E, R, N),sep='\n')

```
