### PR TITLE
250522 : [BOJ 18427] 함께 블록 쌓기

### DIFF
--- a/_youn/boj_18427.py
+++ b/_youn/boj_18427.py
@@ -1,0 +1,13 @@
+N, M, H = map(int, input().split())
+Blocks = [list(map(int, input().split())) for _ in range(N)]
+
+dp = [[0] * (H+1) for _ in range(N+1)]
+dp[0][0] = 1
+
+for i, row in enumerate(Blocks):
+    dp[i+1] = dp[i][:]
+    for b in row:
+        for h in range(b, H+1):
+            dp[i+1][h] += dp[i][h - b] % 10007
+
+print(dp[N][H] % 10007)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1106}

## 🧩 문제 해결

**스스로 해결:** ❌ 1h 20m

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** `dp`
- 🔹 **어떤 방식으로 접근했는지**
- `dp[i][h]`는 `i`번째 학생까지의 블록을 고려했을 때 높이 `h`를 만들 수 있는 경우의 수입니다. 점화식은 다음과 같이 작성됩니다:
    - `dp[i+1][h] += dp[i][h - b]`
- 초기 점화식을 정의했을 때 `dp[i][h]`도 함께 더해줬으나, 이 경우 같은 `dp[i][h]`가 중복 합산되는 문제가 발생합니다.
- 실제로는 한 번만 고려되어야 할 경우의 수가 불필요하게 여러 번 더해지기 때문에, `dp[i+1] = dp[i][:]`로 아무 블록도 선택하지 않았을 때의 경우의 수를 미리 복사해두는 방식으로 수정했습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N*M*H)`
- **이유:**

## 💻 구현 코드

``` Python
N, M, H = map(int, input().split())
Blocks = [list(map(int, input().split())) for _ in range(N)]

dp = [[0] * (H+1) for _ in range(N+1)]
dp[0][0] = 1

for i, row in enumerate(Blocks):
    dp[i+1] = dp[i][:]
    for b in row:
        for h in range(b, H+1):
            dp[i+1][h] += dp[i][h - b] % 10007

print(dp[N][H] % 10007)

```
