### PR TITLE
250529 : [BOJ 18290] NM과 K (1)

### DIFF
--- a/_youn/boj_18290.py
+++ b/_youn/boj_18290.py
@@ -1,0 +1,32 @@
+import sys
+
+def isBlocked(i, j, visited, N, M):
+    for dx, dy in [(0, 1), (1, 0), (-1, 0), (0, -1)]:
+        ni, nj = i+dx, j+dy
+        if 0 <= ni < N and 0 <= nj < M and visited[ni][nj]: return True
+    return False
+
+def solve(depth, total, idx):
+    global ans, visited, board, N, M, K
+    if depth == K: # base case
+        ans = max(ans, total)
+        return
+    
+    for pos in range(idx, N*M):
+        i, j = divmod(pos, M)
+
+        if visited[i][j]: continue
+        if isBlocked(i, j, visited, N, M): continue
+
+        visited[i][j] = True
+        solve(depth+1, total + board[i][j], pos+1)
+        visited[i][j] = False
+        
+
+N, M, K = map(int, sys.stdin.readline().split())
+board = [list(map(int, sys.stdin.readline().split()))\
+         for _ in range(N)]
+ans = -float('inf')
+visited = [[False]*M for _ in range(N)]
+solve(0, 0, 0)
+print(ans)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1140}

## 🧩 문제 해결

**스스로 해결:** ❌

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** `백트래킹`, `브루트포스`
- 🔹 **어떤 방식으로 접근했는지**
- 백트래킹을 통해 `depth`가 `K`가 도달했을 때 `ans`의 값을 갱신하고 함수를 종료합니다.
- `N*M`개의 좌표에 대해서 브루트포스 탐색을 하며, 이때 `divmod` 내장함수를 사용해 좌표를 구합니다.
- `visited`를 통해 선택한 좌표들을 관리하며, 이전에 선택했거나 이전에 선택한 좌표의 인접한 영역에 있을 경우 그 다음 좌표를 탐색하는 방식으로 구현했습니다.
- 초반에 문제를 풀었을 때 매번 전체 순회하는 방식으로 코드를 구현했었는데 시간 초과가 발생했습니다. 따라서 `visited`를 통해 관리하는 방식으로 수정했으며, 같은 백트래킹, 브루트포스 문제라 하더라도 `pruning`을 어떻게 하는지에 따라 시간복잡도가 달라짐을 알게 되었습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(?)`
- **이유:**

## 💻 구현 코드

```Python
import sys

def isBlocked(i, j, visited, N, M):
    for dx, dy in [(0, 1), (1, 0), (-1, 0), (0, -1)]:
        ni, nj = i+dx, j+dy
        if 0 <= ni < N and 0 <= nj < M and visited[ni][nj]: return True
    return False

def solve(depth, total, idx):
    global ans, visited, board, N, M, K
    if depth == K: # base case
        ans = max(ans, total)
        return
    
    for pos in range(idx, N*M):
        i, j = divmod(pos, M)

        if visited[i][j]: continue
        if isBlocked(i, j, visited, N, M): continue

        visited[i][j] = True
        solve(depth+1, total + board[i][j], pos+1)
        visited[i][j] = False
        

N, M, K = map(int, sys.stdin.readline().split())
board = [list(map(int, sys.stdin.readline().split()))\
         for _ in range(N)]
ans = -float('inf')
visited = [[False]*M for _ in range(N)]
solve(0, 0, 0)
print(ans)
```
