### PR TITLE
250529 : [BOJ 12869] 뮤탈리스크

### DIFF
--- a/_youn/boj_12869.py
+++ b/_youn/boj_12869.py
@@ -1,0 +1,22 @@
+import sys
+from itertools import permutations
+from collections import deque
+
+def bfs(SCV):
+    visited = [[[0]*61 for _ in range(61)] for _ in range(61)]
+    queue = deque([SCV])
+    visited[SCV[0]][SCV[1]][SCV[2]] = 0
+
+    while queue:
+        scv1, scv2, scv3 = queue.popleft()
+
+        for a, b, c in permutations([9,3,1]):
+            c_scv1, c_scv2, c_scv3 = max(0, scv1 - a), max(0, scv2 - b), max(0, scv3 - c)
+            if not visited[c_scv1][c_scv2][c_scv3]:
+                queue.append((c_scv1, c_scv2, c_scv3))
+                visited[c_scv1][c_scv2][c_scv3] = visited[scv1][scv2][scv3] + 1
+    return visited[0][0][0]
+
+N = int(sys.stdin.readline())
+SCV = list(map(int, sys.stdin.readline().split()))+[0]*(3-N)
+print(bfs(SCV))


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1152}

## 🧩 문제 해결

**스스로 해결:** ✅ 50m

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** `bfs`, `dp`
- 🔹 **어떤 방식으로 접근했는지**
- `SCV`들의 체력을 좌표처럼 상태로 정의했고, 이를 bfs 알고리즘을 통해 탐색하며 문제를 해결했습니다.
- `visited`는 3차원 배열로, 각 `SCV`의 체력 상태를 인덱스로 사용했으며 `visited[i][j][k]`에는 경우의 수를 저장했습니다.
- 매 턴마다 뮤탈리스크가 공격할 수 있는 모든 경우의 수(9,3,1 데미지의 순열)를 고려해 각 상태별로 `visited`에 최소 공격 횟수를 기록하는 방식으로 풀었습니다.
- bfs의 visited를 dp처럼 활용해 최솟값을 탐색해나갈 수 있음을 알게되었습니다!

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(V+E)`
- **이유:**

## 💻 구현 코드

```Python
import sys
from itertools import permutations
from collections import deque

def bfs(SCV):
    visited = [[[0]*61 for _ in range(61)] for _ in range(61)]
    queue = deque([SCV])
    visited[SCV[0]][SCV[1]][SCV[2]] = 0

    while queue:
        scv1, scv2, scv3 = queue.popleft()

        for a, b, c in permutations([9,3,1]):
            c_scv1, c_scv2, c_scv3 = max(0, scv1 - a), max(0, scv2 - b), max(0, scv3 - c)
            if not visited[c_scv1][c_scv2][c_scv3]:
                queue.append((c_scv1, c_scv2, c_scv3))
                visited[c_scv1][c_scv2][c_scv3] = visited[scv1][scv2][scv3] + 1
    return visited[0][0][0]

N = int(sys.stdin.readline())
SCV = list(map(int, sys.stdin.readline().split()))+[0]*(3-N)
print(bfs(SCV))
```
