### PR TITLE
250620 : [BOJ 2665] 미로만들기

### DIFF
--- a/_eunjin/2665_미로만들기.py
+++ b/_eunjin/2665_미로만들기.py
@@ -1,0 +1,51 @@
+import sys
+import heapq
+input = sys.stdin.readline
+
+INF = int(1e9)
+
+N = int(input())
+matrix = [list(input().strip()) for _ in range(N)]
+
+# 다익스트라
+# 다음 노드가 흰 칸이면 비용 0
+# 다음 노드가 검은 칸이면 비용 1
+# 최단 경로 찾기
+
+# for row in matrix:
+#     for elem in row:
+#         print(elem, end=" ")
+#     print()
+
+dist = [[INF] * N for _ in range(N)]
+dy = [1, 0, -1, 0]
+dx = [0, -1, 0, 1]
+
+def dijkstra():
+    q = []
+    dist[0][0] = 0  # 시작 노드
+    heapq.heappush(q, (0, 0, 0))  # d,y,x
+    while q:
+        curr_dist, cy, cx = heapq.heappop(q)
+
+        if dist[cy][cx] < curr_dist:  # 최단 경로 아님
+            continue
+
+        for i in range(4):
+            ny, nx = cy + dy[i], cx + dx[i]
+
+            if ny < 0 or ny >= N or nx < 0 or nx >= N:
+                continue
+
+            temp_dist = curr_dist
+
+            if matrix[ny][nx] == "0":
+                temp_dist += 1
+
+            if temp_dist < dist[ny][nx]:  # 이 경로가 최단 경로이면
+                dist[ny][nx] = temp_dist
+                heapq.heappush(q, (temp_dist, ny, nx))
+
+
+dijkstra()
+print(dist[N - 1][N - 1])


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1283}

## 🧩 문제 해결

**스스로 해결:** ✅ 35M

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** 다익스트라
- 🔹 **어떤 방식으로 접근했는지** 다익스트라로 최단 경로를 찾는 로직을 이용했습니다. 각 노드마다 네 방향으로 이동하되, 다음 노드가 흰 칸이면 이동 비용은 0, 검은 칸이면 이동 비용은 1로 생각했습니다. dist 행렬에 해당 (y,x)에 도달하기 위해 최소한으로 거쳐야 할 검은 칸의 개수(=이동 비용)을 저장했습니다. 우선순위 큐에 방문한 노드와 이동 비용을 저장해서, 이동 비용이 가장 작은 노드를 뽑아서 다음 경로를 결정하도록 했습니다.
다익스트라 탐색이 모두 끝나고 dist[N-1][N-1]에는 (N,N)에 도달하기 위해 최소한으로 거쳐야 할 검은 칸의 개수가 저장되어 있을 것이므로 바로 출력했습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(?)`
- **이유:** 모르겠습니다... 다익스트라 시간복잡도

## 💻 구현 코드

```python
import sys
import heapq
input = sys.stdin.readline

INF = int(1e9)

N = int(input())
matrix = [list(input().strip()) for _ in range(N)]

# 다익스트라
# 다음 노드가 흰 칸이면 비용 0
# 다음 노드가 검은 칸이면 비용 1
# 최단 경로 찾기

# for row in matrix:
#     for elem in row:
#         print(elem, end=" ")
#     print()

dist = [[INF] * N for _ in range(N)]
dy = [1, 0, -1, 0]
dx = [0, -1, 0, 1]

def dijkstra():
    q = []
    dist[0][0] = 0  # 시작 노드
    heapq.heappush(q, (0, 0, 0))  # d,y,x
    while q:
        curr_dist, cy, cx = heapq.heappop(q)

        if dist[cy][cx] < curr_dist:  # 최단 경로 아님
            continue

        for i in range(4):
            ny, nx = cy + dy[i], cx + dx[i]

            if ny < 0 or ny >= N or nx < 0 or nx >= N:
                continue

            temp_dist = curr_dist

            if matrix[ny][nx] == "0":
                temp_dist += 1

            if temp_dist < dist[ny][nx]:  # 이 경로가 최단 경로이면
                dist[ny][nx] = temp_dist
                heapq.heappush(q, (temp_dist, ny, nx))


dijkstra()
print(dist[N - 1][N - 1])

```
