### PR TITLE
250620 : [BOJ 2665] 미로만들기

### DIFF
--- a/_youn/boj_2665.py
+++ b/_youn/boj_2665.py
@@ -1,0 +1,25 @@
+import heapq
+
+def dijkstra(board, n):
+    distance = [[float('inf')]*n for _ in range(n)]
+    pq = [(0, 0, 0)]
+    distance[0][0] = 0
+    
+    while pq:
+        cost, x, y = heapq.heappop(pq)
+
+        if cost>distance[x][y]: continue
+        if (x, y) == (n-1, n-1):
+            return cost
+        
+        for dx, dy in [(0, 1), (1, 0), (-1, 0), (0, -1)]:
+            nx, ny = x+dx, y+dy
+            if 0<=nx<n and 0<=ny<n:
+                ncost = cost + abs(board[nx][ny] - 1)
+                if ncost < distance[nx][ny]:
+                    distance[nx][ny] = ncost
+                    heapq.heappush(pq, (ncost, nx, ny))
+
+n = int(input())
+board = [list(map(int, input().strip())) for _ in range(n)]
+print(dijkstra(board, n))


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1283}

## 🧩 문제 해결

**스스로 해결:** ✅ 1h

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** `다익스트라`
- 🔹 **어떤 방식으로 접근했는지**
    - 최소 비용을 갖는 경로를 찾는 문제였으므로 다익스트라 알고리즘을 이용해 접근했습니다.
    - `(0, 0)` 좌표부터 시작해 상하좌우로 이동하며 이동 경로를 탐색합니다. 이때 각 좌표는 가중치와 함께 저장되며 최소 비용인 경로를 최우선으로 탐색하기 위해 우선순위 큐를 사용합니다.
    - 만약 현재 탐색하고  있는 경로의 가중치가 `distance`에 저장된 경로의 가중치 (즉 기존에 탐색한 경로의 가중치)보다 클 경우 해당 경로는 pruning되어 더이상 탐색하지 않습니다.
    - 위 과정을 반복하며 `(n-1, n-1)` 좌표에 도달했을 경우 가중치 값을 반환합니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(NlogN)`
- **이유:**

## 💻 구현 코드

``` Python
import heapq

def dijkstra(board, n):
    distance = [[float('inf')]*n for _ in range(n)]
    pq = [(0, 0, 0)]
    distance[0][0] = 0
    
    while pq:
        cost, x, y = heapq.heappop(pq)

        if cost>distance[x][y]: continue
        if (x, y) == (n-1, n-1):
            return cost
        
        for dx, dy in [(0, 1), (1, 0), (-1, 0), (0, -1)]:
            nx, ny = x+dx, y+dy
            if 0<=nx<n and 0<=ny<n:
                ncost = cost + abs(board[nx][ny] - 1)
                if ncost < distance[nx][ny]:
                    distance[nx][ny] = ncost
                    heapq.heappush(pq, (ncost, nx, ny))

n = int(input())
board = [list(map(int, input().strip())) for _ in range(n)]
print(dijkstra(board, n))
```
