### PR TITLE
250620 : [BOJ 2253] 점프

### DIFF
--- a/_eunjin/2253_점프.py
+++ b/_eunjin/2253_점프.py
@@ -1,0 +1,44 @@
+import sys
+input = sys.stdin.readline
+
+N, M = map(int, input().split())
+INF = int(1e6)
+
+banned = [False] * (N + 1)
+for _ in range(M):
+    banned[int(input().strip())] = True
+
+# dp
+# 2차원 풀이
+# X를 N으로 설정하니까 메모리 초과
+# 어차피 한번에 갈 수 있는 최대 칸은 N보다 훨씬 작음
+X = 150
+dp = [[INF] * X for _ in range(N + 1)]
+dp[2][1] = 1  # 제일 처음엔 한 칸 점프만 가능
+
+for y in range(3, N + 1):
+    if banned[y]:  # 금지된 돌
+        continue
+    for x in range(1, X):  # 1칸 이상 점프해야함함
+        if y - x <= 0:  # 0 ~ 음수 칸에서 시작 불가
+            continue
+        if banned[y - x]:  # 이전 칸이 밴인 경우 불가
+            continue
+
+        val = INF
+
+        if x - 1 > 0 and x - 1 < X:
+            val = min(val, dp[y - x][x - 1])
+        if x > 0:
+            val = min(val, dp[y - x][x])
+        if x + 1 > 0 and x + 1 < X:
+            val = min(val, dp[y - x][x + 1])
+
+        if val < INF:
+            dp[y][x] = val + 1
+
+answer = -1
+if min(dp[N]) < INF:
+    answer = min(dp[N])
+
+print(answer)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1282}

## 🧩 문제 해결

**스스로 해결:** ❌ 1H

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** dp
- 🔹 **어떤 방식으로 접근했는지** dp 2차원 테이블을 두었습니다. dp[y][x]: y번째 도달했을 때의 최소 점수 횟수, 이전 위치에서 x칸 점프해 도달함으로 정의했습니다. 
![D0BE2D01-7E3E-4822-9252-F8EEBEB87154_1_201_a](https://github.com/user-attachments/assets/ac04e025-07fe-4004-9101-997850bb8f1b)
- dp[y][x]칸에서 가능한 경우의 수는 아래와 같습니다.
1. y-x칸에서 가속 점프한 경우: dp[y-x][x-1]+1
2. y-x킨에서 속도 그대로 점프한 경우: dp[y-x][x]+1
3. y-x칸에서 감속 점프한 경우: dp[y-x][x+1]+1
각 세 케이스를 고려해 val을 셋 중 최솟값으로 만들고, dp[y][x]에 val을 저장했습니다.

그런데 처음에는 dp 배열의 열의 크기를 N으로 설정했고, 계속 메모리 초과가 나왔습니다. 여기서 검색해보니 어차피 한 점프에 갈 수 있는 최대 칸은 N보다 훨씬 작다는 것을 알게 됐습니다.. 총 10칸이 있는 경우, 1번쨰 칸에서 계속 가속만 해서 점프한다고 해도 1+2+3+4 점프로 10번째 칸에 도달 가능합니다. 여기서 한 점프에 갈 수 있는 최대 칸은 4이고, 같은 논리로 dp 배열을 초기화할 때 X를 150으로 설정했습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N)`
- **이유:**

## 💻 구현 코드

```python
import sys
input = sys.stdin.readline

N, M = map(int, input().split())
INF = int(1e6)

banned = [False] * (N + 1)
for _ in range(M):
    banned[int(input().strip())] = True

# dp
# 2차원 풀이
# X를 N으로 설정하니까 메모리 초과
# 어차피 한번에 갈 수 있는 최대 칸은 N보다 훨씬 작음
X = 150
dp = [[INF] * X for _ in range(N + 1)]
dp[2][1] = 1  # 제일 처음엔 한 칸 점프만 가능

for y in range(3, N + 1):
    if banned[y]:  # 금지된 돌
        continue
    for x in range(1, X):  # 1칸 이상 점프해야함함
        if y - x <= 0:  # 0 ~ 음수 칸에서 시작 불가
            continue
        if banned[y - x]:  # 이전 칸이 밴인 경우 불가
            continue

        val = INF

        if x - 1 > 0 and x - 1 < X:
            val = min(val, dp[y - x][x - 1])
        if x > 0:
            val = min(val, dp[y - x][x])
        if x + 1 > 0 and x + 1 < X:
            val = min(val, dp[y - x][x + 1])

        if val < INF:
            dp[y][x] = val + 1

answer = -1
if min(dp[N]) < INF:
    answer = min(dp[N])

print(answer)

```
