### PR TITLE
250624 : [BOJ 2565] 전깃줄 

### DIFF
--- a/_eunjin/2565_전깃줄.py
+++ b/_eunjin/2565_전깃줄.py
@@ -1,0 +1,18 @@
+N = int(input())
+line = [list(map(int, input().split())) for _ in range(N)]
+
+# A를 기준으로 전깃줄 정렬
+line.sort(key=lambda x: x[0])
+
+# 정렬 후 B는 [8,2,9,1,4,6,7,10]
+# 여기서 LIS 길이를 구하면 전깃줄이 교차하지 않는 최대 길이 구할 수 있음
+
+cnt = 0
+dp = [1] * N
+for i in range(N):
+    for j in range(i):
+        if line[i][1] > line[j][1]:
+            dp[i] = max(dp[i], dp[j] + 1)
+    cnt = max(cnt, dp[i])
+
+print(N - cnt)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1298}

## 🧩 문제 해결

**스스로 해결:** ❌ 40M

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** dp
- 🔹 **어떤 방식으로 접근했는지** dp로 풀어야 될 것 같다고 생각해서, 어떻게 점화식을 세워야하는지를 고민하다가 모르겠어서 정답을 봤습니다..... 2차원 dp인줄 알았는데 아니었습니다. 전깃줄을 먼저 A를 기준으로 정렬하고, 정렬한 전깃줄의 B부분에서 LIS(가장 긴 증가하는 부분 수열) 길이를 구하면 되었습니다. 그리고 전체 N에서 그 길이를 빼주면, 전체가 증가하는 수열이 되기 위해 없애야 할 전깃줄의 개수를 구할 수 있었습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N^2)`
- **이유:** dp 테이블 채우는 시간복잡도

## 💻 구현 코드

```python
N = int(input())
line = [list(map(int, input().split())) for _ in range(N)]

# A를 기준으로 전깃줄 정렬
line.sort(key=lambda x: x[0])

# 정렬 후 B는 [8,2,9,1,4,6,7,10]
# 여기서 LIS 길이를 구하면 전깃줄이 교차하지 않는 최대 길이 구할 수 있음

cnt = 0
dp = [1] * N
for i in range(N):
    for j in range(i):
        if line[i][1] > line[j][1]:
            dp[i] = max(dp[i], dp[j] + 1)
    cnt = max(cnt, dp[i])

print(N - cnt)

```
