### PR TITLE
250627 : [BOJ 2479] 경로 찾기

### DIFF
--- a/_eunjin/2479_경로_찾기.py
+++ b/_eunjin/2479_경로_찾기.py
@@ -1,0 +1,46 @@
+import sys
+input = sys.stdin.readline
+
+N, K = map(int, input().split())
+codes = list((input().strip() for _ in range(N)))
+A, B = map(int, input().split())
+
+# 각 노드에 대해 해밍 거리가 1인 노드 미리 계산
+hamming = [[] for _ in range(N)]
+for i in range(N):
+    for j in range(N):
+        if i == j:
+            continue
+
+        cnt = 0
+        for k in range(K):
+            if codes[i][k] != codes[j][k]:
+                cnt += 1
+
+        if cnt == 1:
+            hamming[i].append(j)
+
+
+# dfs로 탐색하면서 현재 노드 기준 해밍 거리가 1인 애들만 다음 탐색 대상 노드로 삼음
+# B노드에 도착하면 즉시 경로 출력
+# 탐색 다 해도 B노드 도착 못하면 -1 출력
+
+def dfs(node):
+    global arr
+    if node == B - 1:
+        print(' '.join(map(str, arr)))
+        exit()
+        return
+
+    for adj_node in hamming[node]:
+        if not visited[adj_node]:
+            visited[adj_node] = True
+            arr.append(adj_node + 1)
+            dfs(adj_node)
+            visited[adj_node] = False
+            arr.pop()
+
+visited = [False] * N
+arr = [A]
+dfs(A - 1)
+print(-1)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1316}

## 🧩 문제 해결

**스스로 해결:** ✅ 20M

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** dfs, 백트래킹
- 🔹 **어떤 방식으로 접근했는지** 먼저, 각 노드에 대해 해밍 거리가 1인 노드 번호를 미리 계산해 hamming 배열에 저장했습니다. 그리고 A노드 부터 시작해 dfs로 탐색하면서 현재 노드 기준으로 해밍 거리가 1인 노드를 다음 탐색 대상으로 삼으면서 탐색했습니다. B노드에 도착하면 즉시 경로를 출력하고, 탐색을 다 했는데도 B노드에 도착하지 못하면 -1을 출력했습니다. dfs+백트래킹 방식으로 풀었는데, python3에서는 시간 초과가 났고 PyPy3로 통과했습니다. 그런데 제출하고 태그를 보니 bfs로도 풀이가 가능한 것 같습니다,, 아마 bfs로 풀어야 python3로 통과가 가능한 것 같습니다..!

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(?)`
- **이유:**

## 💻 구현 코드

```python
import sys
input = sys.stdin.readline

N, K = map(int, input().split())
codes = list((input().strip() for _ in range(N)))
A, B = map(int, input().split())

# 각 노드에 대해 해밍 거리가 1인 노드 미리 계산
hamming = [[] for _ in range(N)]
for i in range(N):
    for j in range(N):
        if i == j:
            continue

        cnt = 0
        for k in range(K):
            if codes[i][k] != codes[j][k]:
                cnt += 1

        if cnt == 1:
            hamming[i].append(j)


# dfs로 탐색하면서 현재 노드 기준 해밍 거리가 1인 애들만 다음 탐색 대상 노드로 삼음
# B노드에 도착하면 즉시 경로 출력
# 탐색 다 해도 B노드 도착 못하면 -1 출력

def dfs(node):
    global arr
    if node == B - 1:
        print(' '.join(map(str, arr)))
        exit()
        return

    for adj_node in hamming[node]:
        if not visited[adj_node]:
            visited[adj_node] = True
            arr.append(adj_node + 1)
            dfs(adj_node)
            visited[adj_node] = False
            arr.pop()

visited = [False] * N
arr = [A]
dfs(A - 1)
print(-1)

```
