### PR TITLE
250704 : [BOJ 12764] 싸지방에 간 준하

### DIFF
--- a/_eunjin/12764_싸지방에_간_준하.py
+++ b/_eunjin/12764_싸지방에_간_준하.py
@@ -9,38 +9,26 @@ info = [list(map(int, input().split())) for _ in range(N)]
 # 컴퓨터 최소 개수, 각 컴퓨터별 사용한 사람 수
 
 # 시작 시간 순으로 정렬해 앞에서부터 배정
-info.sort(key=lambda x: [x[0], x[1]])
+info.sort(key=lambda x: x[0])
 
-pq = []  # 컴퓨터 우선순위큐 (사용 종료 시간, 컴퓨터 번호, 누적 사용자 수)
+using = []  # 사용중인 컴퓨터 우선순위큐 (사용 종료 시간, 컴퓨터 번호) -> 얘는 사용 종료 시간 기준 최솟값을 뽑는 용도
+empty = []  # 비어있는 컴퓨터 우선순위큐 (컴퓨터 번호) -> 얘는 컴퓨터 번호 기준 최솟값을 뽑는 용도
+computer_users = []  # 컴퓨터별 사용자수
 
-num = 0
 for start, end in info:
-    if pq:  # 컴퓨터가 있으면
-        if pq[0][0] < start:  # 앞 사용자가 다 쓰고 나간 경우
-            # 비어있는 컴퓨터 모두 찾기
-            empty_computers = []
-            while pq and pq[0][0] < start:
-                empty_computers.append(heapq.heappop(pq))
+    # 현재 시간 기준 using 큐에서 사용 가능한 컴퓨터 뽑아서 empty 큐로 옮김
+    while using and using[0][0] <= start:
+        _, num = heapq.heappop(using)
+        heapq.heappush(empty, num)
 
-            empty_computers.sort(key=lambda x: x[1])  # 컴퓨터 번호 순으로 정렬
-            # print("empty_computers:", empty_computers)
+    if empty:  # 비어있는 컴퓨터가 있으면
+        num = heapq.heappop(empty)  # empty큐에서 하나 뽑아서 사용 처리
+        computer_users[num] += 1
+    else:  # 비어있는 컴퓨터 없으면
+        num = len(computer_users)  # 새 컴퓨터 추가
+        computer_users.append(1)
 
-            # 컴퓨터 사용 처리
-            use = empty_computers[0]
-            heapq.heappush(pq, (end, use[1], use[2] + 1))
+    heapq.heappush(using, (end, num))  # 현재 유저가 사용할 컴퓨터 using 큐에 추가
 
-            # 나머지 비어있는 컴퓨터는 그대로 pq에 넣기
-            for i in range(1, len(empty_computers)):
-                heapq.heappush(pq, empty_computers[i])
-        else:  # 새 컴퓨터 추가 필요한 경우
-            num += 1
-            heapq.heappush(pq, (end, num, 1))
-    else:  # 컴퓨터 없으면 새 컴퓨터 추가
-        num += 1
-        heapq.heappush(pq, (end, num, 1))
-
-
-pq.sort(key=lambda x: x[1])
-
-print(len(pq))
-print(' '.join(map(str, list(user for _, _, user in pq))))
+print(len(computer_users))
+print(*computer_users)

--- a/_eunjin/12764_싸지방에_간_준하.py
+++ b/_eunjin/12764_싸지방에_간_준하.py
@@ -1,0 +1,46 @@
+import sys
+import heapq
+input = sys.stdin.readline
+
+N = int(input())
+info = [list(map(int, input().split())) for _ in range(N)]
+
+# 비어있는 자리 중에서 번호 가장 작은 것에 앉음
+# 컴퓨터 최소 개수, 각 컴퓨터별 사용한 사람 수
+
+# 시작 시간 순으로 정렬해 앞에서부터 배정
+info.sort(key=lambda x: [x[0], x[1]])
+
+pq = []  # 컴퓨터 우선순위큐 (사용 종료 시간, 컴퓨터 번호, 누적 사용자 수)
+
+num = 0
+for start, end in info:
+    if pq:  # 컴퓨터가 있으면
+        if pq[0][0] < start:  # 앞 사용자가 다 쓰고 나간 경우
+            # 비어있는 컴퓨터 모두 찾기
+            empty_computers = []
+            while pq and pq[0][0] < start:
+                empty_computers.append(heapq.heappop(pq))
+
+            empty_computers.sort(key=lambda x: x[1])  # 컴퓨터 번호 순으로 정렬
+            # print("empty_computers:", empty_computers)
+
+            # 컴퓨터 사용 처리
+            use = empty_computers[0]
+            heapq.heappush(pq, (end, use[1], use[2] + 1))
+
+            # 나머지 비어있는 컴퓨터는 그대로 pq에 넣기
+            for i in range(1, len(empty_computers)):
+                heapq.heappush(pq, empty_computers[i])
+        else:  # 새 컴퓨터 추가 필요한 경우
+            num += 1
+            heapq.heappush(pq, (end, num, 1))
+    else:  # 컴퓨터 없으면 새 컴퓨터 추가
+        num += 1
+        heapq.heappush(pq, (end, num, 1))
+
+
+pq.sort(key=lambda x: x[1])
+
+print(len(pq))
+print(' '.join(map(str, list(user for _, _, user in pq))))


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1361}

## 🧩 문제 해결

**스스로 해결:** ❌

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** 우선순위큐
- 🔹 **어떤 방식으로 접근했는지** 처음에는 우선순위 큐 1개에 현재 사용중인 컴퓨터 정보(사용 종료 시간, 컴퓨터 번호, 누적 사용자 수)를 넣도록 했습니다. 주어진 유저 사용 시간을 시작시간 기준 오름차순으로 정렬한 뒤에, 각 유저를 순차적으로 따져보았습니다. pq에 현재 유저의 시작 시간보다 일찍 사용 종료된 컴퓨터가 있으면 그것을 모두 큐에서 뺀 뒤, empty_computers 배열에 임시로 저장하였습니다. 그리고 컴퓨터 번호가 제일 작은 1개를 사용 처리하고, 나머지 컴퓨터는 그대로 pq에 넣도록 했습니다. 그런데 이렇게 구현했더니 10%에서 시간초과가 발생했고, 아마 비어있는 컴퓨터가 아주 많을 때 그것을 전부 pop했다가 push하는게  최악의 경우O(NlogN)까지 갈 수 있고, 이걸 각 유저마다 반복하면 O(N^2logN) 복잡도가 나와서 그랬던 것 같습니다ㅏ.. 결국 정답 코드를 참고하여, 우선 순위 큐를 2개 사용하는 방식으로 수정했습니다. using 큐에는 현재 사용중인 컴퓨터를 사용 종료 시간을 기준으로 관리하고, empty 큐에서는 비어있는 컴퓨터를 컴퓨터 번호 기준으로 관리하도록 했습니다. 컴퓨터 번호 기준으로 최솟값을 찾을 수 있는 큐를 추가했기 때문에, 각 사용자마다 O(logN)의 시간 복잡도로 계산이 가능하게 되어 풀이가 통과되었습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(NlogN)`
- **이유:** N명의 사용자마다 heappish, heappop `O(logN)`

## 💻 구현 코드

```python
import sys
import heapq
input = sys.stdin.readline

N = int(input())
info = [list(map(int, input().split())) for _ in range(N)]

# 비어있는 자리 중에서 번호 가장 작은 것에 앉음
# 컴퓨터 최소 개수, 각 컴퓨터별 사용한 사람 수

# 시작 시간 순으로 정렬해 앞에서부터 배정
info.sort(key=lambda x: x[0])

using = []  # 사용중인 컴퓨터 우선순위큐 (사용 종료 시간, 컴퓨터 번호) -> 얘는 사용 종료 시간 기준 최솟값을 뽑는 용도
empty = []  # 비어있는 컴퓨터 우선순위큐 (컴퓨터 번호) -> 얘는 컴퓨터 번호 기준 최솟값을 뽑는 용도
computer_users = []  # 컴퓨터별 사용자수

for start, end in info:
    # 현재 시간 기준 using 큐에서 사용 가능한 컴퓨터 뽑아서 empty 큐로 옮김
    while using and using[0][0] <= start:
        _, num = heapq.heappop(using)
        heapq.heappush(empty, num)

    if empty:  # 비어있는 컴퓨터가 있으면
        num = heapq.heappop(empty)  # empty큐에서 하나 뽑아서 사용 처리
        computer_users[num] += 1
    else:  # 비어있는 컴퓨터 없으면
        num = len(computer_users)  # 새 컴퓨터 추가
        computer_users.append(1)

    heapq.heappush(using, (end, num))  # 현재 유저가 사용할 컴퓨터 using 큐에 추가

print(len(computer_users))
print(*computer_users)

```
