### PR TITLE
250707 : [BOJ 19538] 루머

### DIFF
--- a/_eunjin/19538_루머.py
+++ b/_eunjin/19538_루머.py
@@ -1,0 +1,40 @@
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+N = int(input())
+
+adj_list = [[] for _ in range(N + 1)]
+
+for i in range(1, N + 1):
+    nodes = list(map(int, input().split()))
+
+    for n in nodes:
+        if n != 0:
+            adj_list[i].append(n)
+
+M = int(input())
+start = list(map(int, input().split()))
+
+adj_believed = [0] * (N + 1)  # 루머 믿는 주변인의 수
+believed = [-1] * (N + 1)  # i번째 노드가 루머 처음 믿기 시작한 시간
+
+q = deque()
+for st in start:
+    q.append((st, 0))  # node, d
+    believed[st] = 0
+
+while q:
+    node, d = q.popleft()
+
+    for adj_node in adj_list[node]:
+        if believed[adj_node] >= 0:
+            continue
+
+        adj_believed[adj_node] += 1
+
+        if adj_believed[adj_node] * 2 >= len(adj_list[adj_node]):  # 인접 노드의 절반 이상이 루머 믿으면 자신도 믿음
+            believed[adj_node] = d + 1
+            q.append((adj_node, d + 1))
+
+print(*believed[1:])


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1376}

## 🧩 문제 해결

**스스로 해결:** ✅ 50M

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** bfs
- 🔹 **어떤 방식으로 접근했는지** bfs로 탐색을 진행하도록 했습니다. 이때, 각 노드마다 자신의 주변인 절반 이상이 루머를 믿어야한다는 조건이 있으므로, 각 노드별 루머를 믿는 주변인의 수를 저장하는 adj_believed 배열을 별도로 두었습니다. bfs visited와 비슷한 개념으로 believed 배열을 두어, i 번째 노드가 루머를 처음으로 믿기 시작한 시간을 저장하도록 했습니다. 주어진 최초유포자 노드부터 시작해서, 자신의 인접 노드 중 believed가 -1인 노드를 대상으로 adj_believed 값을 1 늘려준 뒤에, 인접 노드가 루머를 믿게 되었다면 해당 인접 노드를 큐에 추가해주었습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N+간선 개수)`
- **이유:**

## 💻 구현 코드

```python
import sys
from collections import deque
input = sys.stdin.readline

N = int(input())

adj_list = [[] for _ in range(N + 1)]

for i in range(1, N + 1):
    nodes = list(map(int, input().split()))

    for n in nodes:
        if n != 0:
            adj_list[i].append(n)

M = int(input())
start = list(map(int, input().split()))

adj_believed = [0] * (N + 1)  # 루머 믿는 주변인의 수
believed = [-1] * (N + 1)  # i번째 노드가 루머 처음 믿기 시작한 시간

q = deque()
for st in start:
    q.append((st, 0))  # node, d
    believed[st] = 0

while q:
    node, d = q.popleft()

    for adj_node in adj_list[node]:
        if believed[adj_node] >= 0:
            continue

        adj_believed[adj_node] += 1

        if adj_believed[adj_node] >= len(adj_list[adj_node]) / 2:  # 인접 노드의 절반 이상이 루머 믿으면 자신도 믿음
            believed[adj_node] = d + 1
            q.append((adj_node, d + 1))

print(*believed[1:])

```
