### PR TITLE
250710 : [BOJ 2412] 암벽 등반

### DIFF
--- a/_hyunseo/1399.py
+++ b/_hyunseo/1399.py
@@ -1,0 +1,49 @@
+import sys
+from collections import defaultdict, deque
+
+input = sys.stdin.readline
+
+n, T = map(int, input().split())
+
+board = []
+grid = defaultdict(list)
+block_size = 3
+
+for _ in range(n):
+    x, y = map(int, input().split())
+    board.append((x, y))
+    
+    gx = x // block_size
+    gy = y // block_size
+    grid[(gx, gy)].append((x, y))
+
+visited = set()
+q = deque()
+q.append((0, 0, 0))   # (x, y, cnt)
+
+answer = float('inf')
+
+while q:
+    x, y, cnt = q.popleft()
+
+    if y == T:
+        print(cnt)
+        exit()
+
+    # 현재 블록 좌표
+    bx = x // block_size
+    by = y // block_size
+
+    # 주변 9개의 블록만 검사
+    for dx in [-1, 0, 1]:
+        for dy in [-1, 0, 1]:
+            nbx = bx + dx
+            nby = by + dy
+
+            for a, b in grid.get((nbx, nby), []):
+                if abs(a - x) <= 2 and abs(b - y) <= 2:
+                    if (a, b) not in visited:
+                        visited.add((a, b))
+                        q.append((a, b, cnt + 1))
+
+print(-1)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1399}

## 🧩 문제 해결

**스스로 해결:** ❌

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** : bfs, 그리드 해시
- 🔹 **어떤 방식으로 접근했는지** : bfs로 최단 경로 검색, 그리드 해시로 검색해야 하는 좌표 한정
### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N)`
- **이유:** 

## 💻 구현 코드

```python
import sys
from collections import defaultdict, deque

input = sys.stdin.readline

n, T = map(int, input().split())

board = []
grid = defaultdict(list)
block_size = 3

for _ in range(n):
    x, y = map(int, input().split())
    board.append((x, y))
    
    gx = x // block_size
    gy = y // block_size
    grid[(gx, gy)].append((x, y))

visited = set()
q = deque()
q.append((0, 0, 0))   # (x, y, cnt)

answer = float('inf')

while q:
    x, y, cnt = q.popleft()

    if y == T:
        print(cnt)
        exit()

    # 현재 블록 좌표
    bx = x // block_size
    by = y // block_size

    # 주변 9개의 블록만 검사
    for dx in [-1, 0, 1]:
        for dy in [-1, 0, 1]:
            nbx = bx + dx
            nby = by + dy

            for a, b in grid.get((nbx, nby), []):
                if abs(a - x) <= 2 and abs(b - y) <= 2:
                    if (a, b) not in visited:
                        visited.add((a, b))
                        q.append((a, b, cnt + 1))

print(-1)


```

##### 1차 시도

처음에는 모든 가능성을 다 봐야 한다고 생각해서 dfs로 풀었습니다. 
암벽등반으로 갈 수 있는 점들은 dfs로 계속 탐색하도록 했습니다. 근데 이러면 시간 초과가 나서, sys.stdin.readline을 사용했더니, 이번에는 recursion error가 떠서, setlimit을 설정했음에도 불구하고 recursion error가 떠서, dfs가 방법이 아니라는 것을 알게 되었습니다. (항상 최단 경로는 BFS죠... ㅠㅠ )
```python
import sys
input = sys.stdin.readline
sys.setrecursionlimit(10**2)

n , T = map(int, input().split())
board = []
for _ in range(n) :
    x,y = map(int, input().split())
    board.append([x,y])
    
answer = float('inf')
# dfs
def dfs(a,b, visited, cnt) :
    global answer
    if b == T :
        answer = min(answer, cnt)
    for idx, val in enumerate(board ) :
        x, y = val
        if visited[idx] == 0 and abs(a-x) <= 2 and abs(b-y) <= 2 :
            visited[idx] = 1
            dfs(x,y,visited, cnt+1)
dfs(0,0,[0]*n,0)
if answer is float('inf') :
    print(-1)
else :
    print(answer)
    
    #최단 경로 문제는 BFS가 더 적합하다. 
```

2. BFS를 사용했습니다. 사실 현재 있는 좌표에서 거리가 2씩 떨어진 암벽들만 탐색하면 되지만, 그렇게 복잡하게 생각하지는 못했습니다. (쉽게 가기 위해서 이렇게 해도 시간 초과가 나지 않을거라고 생각했습니다)

```python
import sys
input = sys.stdin.readline

from collections import deque
n , T = map(int, input().split())
board = []
for _ in range(n) :
    x,y = map(int, input().split())
    board.append([x,y])
    
answer = float('inf')


q = deque()
visited = [0]*n
q.append((0,0,-1, visited))
shortest_path = [float('inf')]* n 
answer = float('inf')
while q :
    x,y, i, visited = q.popleft()
    for idx, val in enumerate(board) :
        a, b = val
        if abs(a-x) <= 2 and abs(b-y) <= 2 :
            if i == -1 :
                shortest_path[idx] =1
                visited[idx] = 1
                q.append((a,b,idx, visited))
                continue
            if visited[idx] == 1 :
                continue
            if shortest_path[i] + 1 < shortest_path[idx] :
                # print(i)
                visited[idx] = 1
                shortest_path[idx] = shortest_path[i] + 1
                q.append((a,b,idx, visited))
                
                
# print(shortest_path)
answer = float('inf')
for idx, path in enumerate(shortest_path ):
    if board[idx][1] == T :
        answer = min(answer, path)
print(answer)
```

3. BFS만 쓰면 통과할 줄 알았는데, 시간 초과가 나서, 모든 점들을 탐색하면 안되고, defaultdict을 사용해서 하나의 점에 대해서 filtering을 한 후에 다른 점을 완전탐색하면 되겠다는 생각이 들어서 해봤지만 그것도 결국에는 거의? 완전 탐색이라서 시간초과가 났습니다


4. GPT 한테 한번 물어봤더니 `disect`라는 라이브러리를 알려줘서, 이를 사용해봤습니다. `disect`에서 `disect_left`, `disect_right`하면 
bisect_left(arr, 3) → “3이 처음 등장할 index”를 알려주는 함수더라구요. (index와 유사) , 이렇게 해도 결국에는 시간 초과가 나서...

5. 해시 격자 그래프라는 것을 사용했습니다.
grid라는 defaultdict에 전체 보드의 좌표들을 //3했을 때로 나눠서  거기에 해당 좌표를 붙인 후, 나중에 탐색할 때는 grid 기준으로 grid 기준으로 일단 탐색할 범위를 좁힌 후에 거기서 점들을 하나하나 꺼내서 탐색하도록 했습니다. 
근데 이건 정답이 아닌 것 같아서(너무 복잡)


6. 아... 너무 쉬운 방법이 있더라구요 
그냥 이동 범위를 설정했으면 됐는데, 너무 복잡하게 풀었던 것 같습니다. 

```python
import sys
from collections import deque
# n : 암벽에 파인 홈의 개수, T : 도달할 높이
n, T = map(int, sys.stdin.readline().rstrip().split())

dot = set()
for i in range(n):
    x, y = map(int, sys.stdin.readline().rstrip().split())
    dot.add((x,y))

queue = deque()
queue.append([0, 0, 0])
flag = False
while queue:
    x, y, count = queue.popleft()
    if y == T:
        flag =True
        break
    for i in range(-2, 3):
        for j in range(-2, 3):
            nx = x + i
            ny = y + j
            if (nx, ny) in dot:
                queue.append([nx, ny, count + 1])
                dot.remove((nx, ny))
                
if flag:
    print(count)
else:
    print(-1)
```



결론 : 최단경로는 BFS, 복잡하면 이동 경로를 한정
