### PR TITLE
250711 : [BOJ 15558] 점프 게임

### DIFF
--- a/_eunjin/15558_점프_게임.py
+++ b/_eunjin/15558_점프_게임.py
@@ -1,0 +1,35 @@
+from collections import deque
+import sys
+input = sys.stdin.readline
+
+N, K = map(int, input().split())
+left = list(input().strip())
+right = list(input().strip())
+matrix = [left, right]
+
+# bfs
+visited = [[False] * N for _ in range(2)]
+q = deque()
+q.append((0, 0, 0))  # left/right, n, time
+
+dk = [[0, 0, 1], [0, 0, -1]]  # 왼쪽 / 오른쪽
+dn = [[1, -1, K], [1, -1, K]]  # 위 1칸, 아래 1칸, 위 K칸
+
+while q:
+    k, n, t = q.pop()
+
+    for i in range(3):
+        nk = k + dk[k][i]
+        nn = n + dn[k][i]
+
+        if 0 <= nk <= 1 and 0 <= nn:
+            if nn > t:
+                if nn >= N:
+                    print("1")
+                    exit()
+
+                if matrix[nk][nn] == "1" and not visited[nk][nn]:
+                    q.append((nk, nn, t + 1))
+                    visited[nk][nn] = True
+
+print("0")


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1406}

## 🧩 문제 해결

**스스로 해결:** ✅

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** bfs
- 🔹 **어떤 방식으로 접근했는지** 같은 쪽 위/아래로 한 칸 이동, 반대쪽 위로 K칸 이동 가능으로 보고 bfs로 구현했습니다. bfs 큐에 (왼/오른쪽, 칸 번호, depth)로 하나의 노드 정보를 저장하고, 큐에서 노드를 하나씩 뽑아서 dk,dn에 미리 저장해둔 3가지 이동방향에 따라 다음 노드를 방문 가능한지 여부를 판단했습니다. 만약 여기서 다음 노드의 번호가 N을 넘어가면, 그 방향으로 이동해 게임을 끝낼 수 있는것으로 보고 1을 출력, 프로그램을 종료했습니다. 다음 노드의 번호가 N을 넘어가지 않는다면, 다음 노드가 "1" 칸인지 보고, 큐에 담아주며 다음 탐색을 진행하도록 했습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(?)`
- **이유:**

## 💻 구현 코드

```python
from collections import deque
import sys
input = sys.stdin.readline

N, K = map(int, input().split())
left = list(input().strip())
right = list(input().strip())
matrix = [left, right]

# bfs
visited = [[False] * N for _ in range(2)]
q = deque()
q.append((0, 0, 0))  # left/right, n, time

dk = [[0, 0, 1], [0, 0, -1]]  # 왼쪽 / 오른쪽
dn = [[1, -1, K], [1, -1, K]]  # 위 1칸, 아래 1칸, 위 K칸

while q:
    k, n, t = q.pop()

    for i in range(3):
        nk = k + dk[k][i]
        nn = n + dn[k][i]

        if 0 <= nk <= 1 and 0 <= nn:
            if nn > t:
                if nn >= N:
                    print("1")
                    exit()

                if matrix[nk][nn] == "1" and not visited[nk][nn]:
                    q.append((nk, nn, t + 1))
                    visited[nk][nn] = True

print("0")

```
