### PR TITLE
250716 : [BOJ 2179] 비슷한 단어

### DIFF
--- a/_hyunseo/2179.py
+++ b/_hyunseo/2179.py
@@ -1,0 +1,44 @@
+import sys
+from collections import defaultdict
+input = sys.stdin.readline
+N = int(input())
+arr =[]
+for _ in range(N) :
+    arr.append(input().strip())
+dic = defaultdict(list) 
+for idx, word in enumerate(arr) :
+    dic[word[0]].append((word, idx))
+
+def check_words(w1, w2 ) :
+    min_len = min(len(w1), len(w2) )
+    cnt = 0
+    for idx in range(min_len) :
+        if w1[idx] != w2[idx] :
+            return cnt
+        cnt += 1
+    return cnt
+'''
+~~^^^
+TypeError: *list[1] is not a generic class -> for w2 in list[A] (배열이 아니라 수 넣음)
+'''
+def check_list(lst : list) :
+    overlap = [0,'','']
+    
+    for idx, w1 in enumerate(lst[:-1]) :
+        for w2 in lst[idx+1:] :
+            print(w1, w2, "--")
+            tmp = check_words(w1[0], w2[0])
+            if tmp > overlap[0] :
+                overlap = [tmp, w1[0], w2[0]]
+    return overlap
+
+answer = [0,'','']
+for key in dic.keys() :
+    if len(dic[key]) == 1 :
+        continue
+    print(dic[key])
+    cnt, w1, w2 = check_list((dic[key]))
+    if cnt > answer[0] :
+        answer = [cnt, w1, w2]
+for t in answer[1:] :
+    print(t)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1433}

## 🧩 문제 해결

**스스로 해결:** ✅

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** : default dict
- 🔹 **어떤 방식으로 접근했는지** : 이중 for문으로 순회를 할 때, 당연히 시간 초과가 뜬다. 그렇기에, 굳이 앞 글자가 같지 않은 경우는 비교를 할 필요도 없기에, default dict(list)을 사용했다. key로는 제일 앞 글자를 사용했고, list에 단어들을 저장했다. (순서도 중요했기에 혹시 몰라서 입력된 순서를 같이 넣었지만 그럴 필요는 없었다. default dict에는 삽입된 순서로만 리스트가 유지 되기에).
- 탐색 범위를 확 줄인 후에는, default dict의 key 기준으로 순회를 했고, 완전 탐색을 진행했다. 

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(?)`
- **이유:** : ?

## 💻 구현 코드

```python
import sys
from collections import defaultdict
input = sys.stdin.readline
N = int(input())
arr =[]
for _ in range(N) :
    arr.append(input().strip())
dic = defaultdict(list)

# 시작 단어를 key로 한 default dict 에 단어를 저장
for idx, word in enumerate(arr) :
    dic[word[0]].append((word, idx))

def check_words(w1, w2 ) :
    '''단어 2개의 겹치는 부분 길이 반환'''
    min_len = min(len(w1), len(w2) )
    cnt = 0
    for idx in range(min_len) :
        if w1[idx] != w2[idx] :
            return cnt
        cnt += 1
    return cnt

def check_list(lst : list) :
    '''리스트의 모든 단어 확인, 제일 긴 겹치는 부분을 가지는 [길이, 단어1, 단어2] 반환 '''
    overlap = [0,'','']
    for idx, w1 in enumerate(lst[:-1]) :
        for w2 in lst[idx+1:] :
            print(w1, w2, "--")
            tmp = check_words(w1[0], w2[0])
            if tmp > overlap[0] :
                overlap = [tmp, w1[0], w2[0]]
    return overlap

# 초기값
answer = [0,'','']

# 첫 알파벳이 같을 때만 탐색
for key in dic.keys() :
    #첫 알파벳이 같은 단어가 없고, 자기 자신만 있을 때
    if len(dic[key]) == 1 :
        continue
    
    # key로 시작하는 단어들 중 가장 긴 겹치는 구간을 갖는 단어
    cnt, w1, w2 = check_list((dic[key]))
    
    # 기존 answer에 저장한 길이보다 긴 경우 갱신
    if cnt > answer[0] :
        answer = [cnt, w1, w2]
        
for t in answer[1:] :
    print(t)

```
