### PR TITLE
250723 : [BOJ 3584] 가장 가까운 공통 조상

### DIFF
--- a/_eunjin/3584_가장_가까운_공통_조상.py
+++ b/_eunjin/3584_가장_가까운_공통_조상.py
@@ -1,0 +1,41 @@
+import sys
+input = sys.stdin.readline
+sys.setrecursionlimit(10000)
+
+T = int(input())
+
+# dfs 두번 하면서 공통 depth 최솟값 찾기
+
+def dfs1(node, d):
+    if node == 0:
+        return
+
+    depth[node] = d
+    next_node = tree[node]
+    dfs1(next_node, d + 1)
+
+def dfs2(node):
+    if depth[node] >= 0:
+        print(node)
+        return
+
+    next_node = tree[node]
+    dfs2(next_node)
+
+
+for _ in range(T):
+    N = int(input())
+    tree = [0] * (N + 1)
+
+    for _ in range(N - 1):
+        a, b = map(int, input().split())
+        tree[b] = a  # b의 부모는 a
+
+    # print(tree)
+
+    depth = [-1] * (N + 1)
+
+    n1, n2 = map(int, input().split())
+    dfs1(n1, 0)
+    dfs2(n2)
+


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1471}

## 🧩 문제 해결

**스스로 해결:** ✅

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** dfs
- 🔹 **어떤 방식으로 접근했는지** dfs를 두번 실행하면서 공통 depth의 최솟값을 찾도록 했습니다. dfs1에서는 우선 주어진 노드에서 시작해 최상단 노드까지 탐색하면서, 각 노드마다의 방문 depth를 리스트에 저장했습니다. depth 리스트가 초기화된 상태에서, dfs2에서는 주어진 노드에서 시작해 최상단 노드까지 탐색하는데, 이때 depth[node]가 0 이상인 노드가 생기면 바로 해당 node를 출력하도록 했습니다. (공통 조상 노드 중 가장 가까운 것을 찾는 것이므로, 가장 처음으로 depth 값이 있는 노드를 dfs2에서 방문했을 때 그 노드가 공통 조상 노드임)

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(T*N)`
- **이유:**

## 💻 구현 코드

```python
import sys
input = sys.stdin.readline
sys.setrecursionlimit(10000)

T = int(input())

# dfs 두번 하면서 공통 depth 최솟값 찾기

def dfs1(node, d):
    if node == 0:
        return

    depth[node] = d
    next_node = tree[node]
    dfs1(next_node, d + 1)

def dfs2(node):
    if depth[node] >= 0:
        print(node)
        return

    next_node = tree[node]
    dfs2(next_node)


for _ in range(T):
    N = int(input())
    tree = [0] * (N + 1)

    for _ in range(N - 1):
        a, b = map(int, input().split())
        tree[b] = a  # b의 부모는 a

    # print(tree)

    depth = [-1] * (N + 1)

    n1, n2 = map(int, input().split())
    dfs1(n1, 0)
    dfs2(n2)


```
