### PR TITLE
250801 : [BOJ 16940] BFS 스페셜 저지

### DIFF
--- a/_eunjin/16940_BFS_스페셜_저지.py
+++ b/_eunjin/16940_BFS_스페셜_저지.py
@@ -9,40 +9,38 @@ for _ in range(N - 1):
     adj_list[a].append(b)
     adj_list[b].append(a)
 
-orders = list(map(int, input().split()))
+order = list(map(int, input().split()))
 
 # 방문하지 않은 정점 큐에 넣을 때 순서 고려하지 않음
 # bfs 방문 경로가 여러개가 나온다.
 # 직전에 어떤 노드를 먼저 큐에 넣었냐에 따라 다음 노드가 달라짐
-# adj_list에서 다음 노드 뽑을 때 주어진 노드가 있으면 그 노드를 큐의 제일 앞에 넣기?
+
+visited = [False] * (N + 1)
+position = [0] * (N + 1)
+
+# 순서 배열에서 각 노드의 순서를 기록
+for i in range(N):
+    position[order[i]] = i
+
+# 각 노드의 인접 리스트를 방문 순서 기준으로 정렬
+for i in range(1, N + 1):
+    adj_list[i].sort(key=lambda x: position[x])
 
 q = deque()
-visited = [False] * (N + 1)
-
-q.append((1, 0))  # node, depth
+q.append(1)
 visited[1] = True
-
-visited_depth = []
+visit_order = []
 
 while q:
-    node, depth = q.popleft()
-    # print("curr node:", node, depth)
-    visited_depth.append(depth)
+    node = q.popleft()
+    visit_order.append(node)
 
     for adj_node in adj_list[node]:
         if not visited[adj_node]:
-            if adj_node == orders[depth + 1]:
-                q.appendleft((adj_node, depth + 1))
-            else:
-                q.append((adj_node, depth + 1))
-
             visited[adj_node] = True
+            q.append(adj_node)
 
-
-# print(visited_depth)
-
-for i in range(1, len(visited_depth)):
-    if visited_depth[i - 1] > visited_depth[i]:
-        print(0)
-        exit()
-print(1)
+if visit_order == order:
+    print(1)
+else:
+    print(0)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1524}

## 🧩 문제 해결

**스스로 해결:** ❌

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** bfs
- 🔹 **어떤 방식으로 접근했는지** 특정 노드의 인접 노드 리스트를 돌면서 다음 방문할 인접 노드를 queue에 넣는 순서에 따라 여러 bfs 방문 경로가 나올 수 있었습니다. 그래서 처음에는 다음 방문할 인접 노드를 queue의 제일 왼쪽에다가 넣는 방식을 생각했지만, 테스트 케이스만 맞추고 제출 결과는 오답으로 나왔습니다... 성윤님 풀이를 보고 각 adj_list를 주어진 방문하고자 하는 순서 번호를 기준으로 정렬해서, bfs 탐색 과정 중 다음 노드를 queue에 넣을 때 반드시 방문하고자 하는 순서대로 넣어지도록 수정했습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(NlogN)`
- **이유:** adj_list를 정렬하는 시간복잡도

## 💻 구현 코드

```python
from collections import deque
import sys
input = sys.stdin.readline

N = int(input())
adj_list = [[] for _ in range(N + 1)]
for _ in range(N - 1):
    a, b = map(int, input().split())
    adj_list[a].append(b)
    adj_list[b].append(a)

order = list(map(int, input().split()))

# 방문하지 않은 정점 큐에 넣을 때 순서 고려하지 않음
# bfs 방문 경로가 여러개가 나온다.
# 직전에 어떤 노드를 먼저 큐에 넣었냐에 따라 다음 노드가 달라짐

visited = [False] * (N + 1)
position = [0] * (N + 1)

# 순서 배열에서 각 노드의 순서를 기록
for i in range(N):
    position[order[i]] = i

# 각 노드의 인접 리스트를 방문 순서 기준으로 정렬
for i in range(1, N + 1):
    adj_list[i].sort(key=lambda x: position[x])

q = deque()
q.append(1)
visited[1] = True
visit_order = []

while q:
    node = q.popleft()
    visit_order.append(node)

    for adj_node in adj_list[node]:
        if not visited[adj_node]:
            visited[adj_node] = True
            q.append(adj_node)

if visit_order == order:
    print(1)
else:
    print(0)

```
