### PR TITLE
250801 : [BOJ 16940] BFS 스페셜 저지 

### DIFF
--- a/_hyunseo/16940.py
+++ b/_hyunseo/16940.py
@@ -1,0 +1,58 @@
+from collections import defaultdict, deque
+import sys
+input = sys.stdin.readline
+
+# 노드 수
+N = int(input())
+
+# 방문 기록 
+visited = [0] *( N+1)
+
+# 연결 리스트 관리
+graph = defaultdict(list)
+for _ in range(N-1) :
+    a, b = map(int, input().split())
+    graph[a].append(b)
+    graph[b].append(a)
+
+# 주어진 BFS 문장
+given = list(map(int, input().split()))
+
+# 1로 시작 안하는 경우는 미리 0 출력, 끝내기
+if given[0] != 1 :
+    print(0)
+    exit()
+
+# 다음으로 방문한 부모 노드는 deque로 관리
+par = deque()
+# BFS 문장 인덱스 관리
+idx = 0
+# 처음 방문할 1은 미리 deque에 추가, 방문 처리
+par.append(given[0])
+visited[1] = 1
+
+# 문장을 다 훑거나, par가 빈 경우
+while par and idx < len(given):
+    # 다음으로 방문한 부모 노드
+    parent = par.popleft()
+    # 부모 노드와 연결된 노드 중 방문되지 않은 노드만 children set에 넣기
+    # -> list였을 때는 시간 초과, set으로 바꾸니 시간 초과 해결
+    c = list(graph[parent])
+    children = set()
+    for child in c :
+        if visited[child] == 0 :
+            children.add(child)
+          
+    # 연결된 모든 자식 노드 순회
+    while children :
+        # 주어진 문장 인덱스(문장 상 다음으로 방문할 노드)
+        curr = given[idx + 1]
+        if curr not in children :
+            print(0)
+            sys.exit()
+        else :
+            par.append(curr)
+            children.remove(curr)
+            idx += 1
+            visited[curr] = 1
+print(1)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1524}

## 🧩 문제 해결

**스스로 해결:** ✅

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** : BFS
- 🔹 **어떤 방식으로 접근했는지** : 현재 노드는 par이라는  deque에 넣고, 현재 노드 중 방문되지 않은 자식 노드들이 주어진 문장에서 나오는지 확인합니다. 그 후로, 자식 노드들도 문장 순서대로 par에 추가합니다. par에서 하나씩 꺼내서, 현재 노드의 자식들이 문장에서 나오는지 확인하면서 진행합니다. 

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N)`
- **이유:** 

## 💻 구현 코드

```python
from collections import defaultdict, deque
import sys
input = sys.stdin.readline

# 노드 수
N = int(input())

# 방문 기록 
visited = [0] *( N+1)

# 연결 리스트 관리
graph = defaultdict(list)
for _ in range(N-1) :
    a, b = map(int, input().split())
    graph[a].append(b)
    graph[b].append(a)

# 주어진 BFS 문장
given = list(map(int, input().split()))

# 1로 시작 안하는 경우는 미리 0 출력, 끝내기
if given[0] != 1 :
    print(0)
    exit()

# 다음으로 방문한 부모 노드는 deque로 관리
par = deque()
# BFS 문장 인덱스 관리
idx = 0
# 처음 방문할 1은 미리 deque에 추가, 방문 처리
par.append(given[0])
visited[1] = 1

# 문장을 다 훑거나, par가 빈 경우
while par and idx < len(given):
    # 다음으로 방문한 부모 노드
    parent = par.popleft()
    # 부모 노드와 연결된 노드 중 방문되지 않은 노드만 children set에 넣기
    # -> list였을 때는 시간 초과, set으로 바꾸니 시간 초과 해결
    c = list(graph[parent])
    children = set()
    for child in c :
        if visited[child] == 0 :
            children.add(child)
          
    # 연결된 모든 자식 노드 순회
    while children :
        # 주어진 문장 인덱스(문장 상 다음으로 방문할 노드)
        curr = given[idx + 1]
        if curr not in children :
            print(0)
            sys.exit()
        else :
            par.append(curr)
            children.remove(curr)
            idx += 1
            visited[curr] = 1
print(1)
```
