### PR TITLE
250807 : [BOJ 9466] 텀 프로젝트

### DIFF
--- a/_hyunseo/9466_bfs.py
+++ b/_hyunseo/9466_bfs.py
@@ -1,0 +1,41 @@
+import sys
+
+input = sys.stdin.readline
+from collections import deque
+
+
+def find_cycle(n, s) :
+    cycles = set()
+    
+    for idx in range(1, n+1) :
+        if idx in cycles or s[idx] in cycles : continue
+        if s == s[idx] : 
+            cycles.add(idx)
+            continue
+        q = deque()
+        visited = set()
+        visited.add(idx)
+        q.append(idx)
+        while q :
+            A = q.popleft()
+            B = s[A]
+            if A in cycles  or B in cycles : break
+            if A == B : 
+                cycles.add(A)    
+                break
+            if B == idx :
+                cycles.add(i for i in visited)
+                break
+            if B not in visited :
+                visited.add(B)
+                q.append(B)
+    print(cycles)
+    return len(cycles)
+
+T = int(input())
+for _ in range(T) :
+    n = int(input())
+    selections = [0]  # 1부터 시작하기 위해
+    selections += list(map(int, input().split()))
+    cycles = find_cycle(n, selections)
+    print(n-cycles)

--- a/_hyunseo/9466_dfs.py
+++ b/_hyunseo/9466_dfs.py
@@ -1,0 +1,37 @@
+import sys
+sys.setrecursionlimit(10**6)
+input = sys.stdin.readline
+from collections import deque
+
+
+def dfs(curr) :
+    global count
+    # 현재 노드 방문 처리
+    visited[curr] = 1
+    # 다음 노드
+    dst = selections[curr]
+    
+    #다음 노드가 아직 방문 X 
+    if visited[dst] == 0 :
+        dfs(dst)
+    elif not finished[dst] :
+        # 사이클
+        tmp = dst
+        cycle_size = 1
+        while tmp != curr :
+            tmp = selections[tmp]
+            cycle_size += 1
+        count += cycle_size
+    finished[curr] = 1
+
+T = int(input())
+for _ in range(T) :
+    n = int(input())
+    selections = [0] + list(map(int, input().split()))
+    visited=[0]*(n+1)
+    finished = [0]*(n+1)
+    count = 0
+    for idx in range(1, n+1) :
+        if visited[idx] == 0 :
+            dfs(idx)
+    print(n - count)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1562}

## 🧩 문제 해결

**스스로 해결:** ✅ 

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** : BFS -> DFS
- 🔹 **어떤 방식으로 접근했는지** : 
- 처음에 BFS로 cycle 탐지하도록 했는데, N의 수가 너무 커서 시간 초과가 떴습니다. 그래서 DFS로 틀었습니다.
- DFS
    - visited와 finished 배열을 관리하면서 visited은 그때그때 방문할 때, 그리고 dfs가 끝났을 때 finished 처리를 해서 중복 처리가 안되도록 관리했습니다.
    - dst = 는 curr가 고른 사람
    - dst가 아직 방문 처리가 되지 않았다면, dfs 처리를 했고
    - dst가 방문처리가 되었고, finished처리가 되지 않았다면 사이클이라고 탐지하여, 다시 while문을 돌면서 cycle_size에 추가했습니다.
    - 이런 방식으로 모든 idx(1~n)까지 돌고, 총 n에서 cycle_size만큼 제외해서 출력했습니다. 

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N)`
- **이유:**

## 💻 구현 코드

```python
import sys
sys.setrecursionlimit(10**6)
input = sys.stdin.readline
from collections import deque


def dfs(curr) :
    global count
    # 현재 노드 방문 처리
    visited[curr] = 1
    # 다음 노드
    dst = selections[curr]
    
    #다음 노드가 아직 방문 X 
    if visited[dst] == 0 :
        dfs(dst)
    elif not finished[dst] :
        # 사이클
        tmp = dst
        cycle_size = 1
        while tmp != curr :
            tmp = selections[tmp]
            cycle_size += 1
        count += cycle_size
    finished[curr] = 1

T = int(input())
for _ in range(T) :
    n = int(input())
    selections = [0] + list(map(int, input().split()))
    visited=[0]*(n+1)
    finished = [0]*(n+1)
    count = 0
    for idx in range(1, n+1) :
        if visited[idx] == 0 :
            dfs(idx)
    print(n - count)
```
