### PR TITLE
⚡️ 250811 : [BOJ 14442] 벽 부수고 이동하기 2

### DIFF
--- a/_eunjin/14442_벽_부수고_이동하기_2.py
+++ b/_eunjin/14442_벽_부수고_이동하기_2.py
@@ -1,0 +1,39 @@
+from collections import deque
+import sys
+input = sys.stdin.readline
+N, M, K = map(int, input().split())
+matrix = [list(input().strip()) for _ in range(N)]
+
+# 일단 bfs탐색하면서 방문한 1의 개수를 같이 큐에 넘기기
+dy = [1, 0, -1, 0]
+dx = [0, 1, 0, -1]
+visited = [[[False] * (K + 1) for _ in range(M)] for _ in range(N)]
+q = deque()
+q.append((0, 0, 1, 0))  # y, x, depth, cnt
+visited[0][0][0] = True
+answer = -1
+
+while q:
+    y, x, depth, cnt = q.popleft()
+
+    if y == N - 1 and x == M - 1:
+        answer = depth
+        break
+
+    for i in range(4):
+        ny, nx = y + dy[i], x + dx[i]
+        if ny < 0 or ny >= N or nx < 0 or nx >= M:
+            continue
+
+        if matrix[ny][nx] == "1":
+            if cnt + 1 > K:  # 더이상 벽 부수기 불가
+                continue
+            if not visited[ny][nx][cnt + 1]:
+                q.append((ny, nx, depth + 1, cnt + 1))
+                visited[ny][nx][cnt + 1] = True
+        else:
+            if not visited[ny][nx][cnt]:
+                q.append((ny, nx, depth + 1, cnt))
+                visited[ny][nx][cnt] = True
+
+print(answer)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1589}

## 🧩 문제 해결

**스스로 해결:** ✅ 25M


### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** bfs
- 🔹 **어떤 방식으로 접근했는지** bfs탐색을 하되, 인접 노드가 1이어도 그동안 방문한 1의 개수가 K 미만이라면 해당 노드를 방문할 수 있는 것으로 생각했습니다. 큐에 현재까지의 경로 중 방문한 1의 개수를 넣어주었고, visited 배열을 3차원으로 설정해서 visited[y][x][k]: (y,x) 좌표에 k번 벽을 부순 상태로 방문했는지 여부를 저장하도록 했습니다. 인접노드가 0일떄는 바로 탐색 큐에 넣어주고, 1일 떄는 현재까지 방문한 1의 개수 +1이 K 미만인지 확이난 뒤에 탐색 큐에 넣어주었습니다. 이렇게 구현하고 Python3로 제출했더니 계속 시간초과가 나서,, 코드 문제인 줄 알고 시간을 낭비했습니다..... 그냥 PyPy로만 가능한 문제인 것 같습니다 ....

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(???)`
- **이유:** 모르겠습니다 . . .

## 💻 구현 코드

```python
from collections import deque
import sys
input = sys.stdin.readline
N, M, K = map(int, input().split())
matrix = [list(input().strip()) for _ in range(N)]

# 일단 bfs탐색하면서 방문한 1의 개수를 같이 큐에 넘기기
dy = [1, 0, -1, 0]
dx = [0, 1, 0, -1]
visited = [[[False] * (K + 1) for _ in range(M)] for _ in range(N)]
q = deque()
q.append((0, 0, 1, 0))  # y, x, depth, cnt
visited[0][0][0] = True
answer = -1

while q:
    y, x, depth, cnt = q.popleft()

    if y == N - 1 and x == M - 1:
        answer = depth
        break

    for i in range(4):
        ny, nx = y + dy[i], x + dx[i]
        if ny < 0 or ny >= N or nx < 0 or nx >= M:
            continue

        if matrix[ny][nx] == "1":
            if cnt + 1 > K:  # 더이상 벽 부수기 불가
                continue
            if not visited[ny][nx][cnt + 1]:
                q.append((ny, nx, depth + 1, cnt + 1))
                visited[ny][nx][cnt + 1] = True
        else:
            if not visited[ny][nx][cnt]:
                q.append((ny, nx, depth + 1, cnt))
                visited[ny][nx][cnt] = True

print(answer)

```
