### PR TITLE
⭐️ 250811 : [BOJ 10216] Count Circle Groups

### DIFF
--- a/_eunjin/10216_Count_Circle_Groups_(2).py
+++ b/_eunjin/10216_Count_Circle_Groups_(2).py
@@ -1,0 +1,46 @@
+from collections import deque
+import sys
+input = sys.stdin.readline
+
+# 특정 원 -> 다른 모든 원에 대해 통신 거리 안에 있는지 여부 파악
+def valid(curr, target):
+    cy, cx, cr = circles[curr]
+    ty, tx, tr = circles[target]
+
+    return (cy - ty)**2 + (cx - tx)**2 <= (cr + tr)**2
+
+def bfs(s):
+    q = deque()
+    q.append(s)  # 원의 인덱스
+    visited[s] = True
+
+    while q:
+        circle = q.popleft()
+
+        for i in range(N):
+            if i == circle:  # 자기 자신은 pass
+                continue
+
+            if not visited[i] and valid(circle, i):
+                q.append(i)
+                visited[i] = True
+
+T = int(input())
+
+for _ in range(T):
+    N = int(input())
+    circles = []
+    answer = 0
+
+    for _ in range(N):
+        circles.append(list(map(int, input().split())))
+
+    visited = [False] * N
+
+    for i in range(N):
+        if not visited[i]:
+            bfs(i)
+            answer += 1
+
+    print(answer)
+


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1586}

## 🧩 문제 해결

**스스로 해결:** ✅ 22M

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** bfs
- 🔹 **어떤 방식으로 접근했는지** 일반적인 bfs 탐색과 동일하게 탐색하되, valid 함수를 통해 현재 원 -> 다른 특정 원에 대해 통신 거리 안에 있는지 여부를 반환하도록 했습니다. bfs 함수에서는 주어진 원과 다른 모든 원에 대해 valid 함수를 실행해서 아직 방문하지 않았고 valid한 경우 인접 노드로 판단하고 방문하도록 했습니다. Python3로는 시간초과, PyPy로만 통과가 되었습니다..

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(?)`
- **이유:**

## 💻 구현 코드

```python
from collections import deque
import sys
input = sys.stdin.readline

# 특정 원 -> 다른 모든 원에 대해 통신 거리 안에 있는지 여부 파악
def valid(curr, target):
    cy, cx, cr = circles[curr]
    ty, tx, tr = circles[target]

    return (cy - ty)**2 + (cx - tx)**2 <= (cr + tr)**2

def bfs(s):
    q = deque()
    q.append(s)  # 원의 인덱스
    visited[s] = True

    while q:
        circle = q.popleft()

        for i in range(N):
            if i == circle:  # 자기 자신은 pass
                continue

            if not visited[i] and valid(circle, i):
                q.append(i)
                visited[i] = True

T = int(input())

for _ in range(T):
    N = int(input())
    circles = []
    answer = 0

    for _ in range(N):
        circles.append(list(map(int, input().split())))

    visited = [False] * N

    for i in range(N):
        if not visited[i]:
            bfs(i)
            answer += 1

    print(answer)
```
