### PR TITLE
⭐️ 250813 : [BOJ 1713] 후보 추천하기

### DIFF
--- a/_eunjin/1713_후보_추천하기.py
+++ b/_eunjin/1713_후보_추천하기.py
@@ -1,0 +1,47 @@
+import sys
+input = sys.stdin.readline
+
+N = int(input())
+R = int(input())
+recommend = list(map(int, input().split()))
+
+# 우선순위큐로 하려고 했으나.. 큐의 특정 인덱스의 값을 수정해야하는데 heapq에서는 불가
+# 딕셔너리에 {학생 번호: [추천 횟수, 게시 시점]} 이렇게 저장하고 완전탐색할까
+# N이 20, 추천 횟수 1,000이라 N*R 가능
+
+_dict = {}
+
+# 삭제할 학생 번호 리턴
+# 1. 추천횟수 적은순, 2. 게시 시점 오래된 순
+def get_min():
+    mn = 1001
+    mn_students = []
+    for key, value in _dict.items():
+        if value[0] == mn:
+            mn_students.append(key)
+        elif value[0] < mn:
+            mn_students = [key]
+            mn = value[0]
+
+    ret = -1
+    oldest = R
+    for st in mn_students:
+        if _dict[st][1] < oldest:
+            ret = st
+            oldest = _dict[st][1]
+
+    return ret
+
+for i in range(R):
+    student = recommend[i]
+
+    if student in _dict:  # 이미 학생의 사진이 게시된 경우
+        _dict[student][0] += 1  # 추천 횟수 증가
+    else:
+        if len(_dict) >= N:  # 비어있는 사진틀 없는 경우
+            mn_student = get_min()
+            del _dict[mn_student]  # 해당 학생 사진틀에서 제거
+
+        _dict[student] = [1, i]
+
+print(*sorted(_dict.keys()))


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1618}

## 🧩 문제 해결

**스스로 해결:** ✅ 31M

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** 해시, 완전탐색
- 🔹 **어떤 방식으로 접근했는지** 처음에는 사진틀을 우선순위큐로 두고, 해당 큐에서 추천받은 횟수가 가장 적은 학생을 뽑는 방식으로 구현하려고 했습니다. 그런데 이미 사진틀에 게시된 학생의 경우 추천 횟수를 +1해주어야 하고, 추천 횟수 값을 임의로 조정해버리면 heapq의 최소힙이 깨지는 것을 발견했습니다. 어차피 N이 최대 20이고, 총 추천 횟수도 1000번이라서 N*R의 완전탐색을 해도 괜찮기 때문에 딕셔너리를 사용하는 방식으로 다시 구현했습니다. _dict에 {학생번호: [추천 횟수, 게시시점]} 형태로 저장하고, 이 _dict를 사진틀처럼 취급했습니다. 삭제할 학생 번호를 찾을 때는 get_min함수를 별도로 구현해서 전체 _dict를 순회하도록 했습니다. 주어진 추천받은 학생을 순차적으로 탐색하면서 _dict에 해당 학생이 존재하는 경우 추천 횟수를 +1 해주고, 해당 학생이 존재하지 않는 경우엔 사진틀에서 기존 학생 제거 및 현재 학생 추가를 해주었습니다.
### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N*R)`
- **이유:**

## 💻 구현 코드

```python
import sys
input = sys.stdin.readline

N = int(input())
R = int(input())
recommend = list(map(int, input().split()))

# 우선순위큐로 하려고 했으나.. 큐의 특정 인덱스의 값을 수정해야하는데 heapq에서는 불가
# 딕셔너리에 {학생 번호: [추천 횟수, 게시 시점]} 이렇게 저장하고 완전탐색할까
# N이 20, 추천 횟수 1,000이라 N*R 가능

_dict = {}

# 삭제할 학생 번호 리턴
# 1. 추천횟수 적은순, 2. 게시 시점 오래된 순
def get_min():
    mn = 1001
    mn_students = []
    for key, value in _dict.items():
        if value[0] == mn:
            mn_students.append(key)
        elif value[0] < mn:
            mn_students = [key]
            mn = value[0]

    ret = -1
    oldest = R
    for st in mn_students:
        if _dict[st][1] < oldest:
            ret = st
            oldest = _dict[st][1]

    return ret

for i in range(R):
    student = recommend[i]

    if student in _dict:  # 이미 학생의 사진이 게시된 경우
        _dict[student][0] += 1  # 추천 횟수 증가
    else:
        if len(_dict) >= N:  # 비어있는 사진틀 없는 경우
            mn_student = get_min()
            del _dict[mn_student]  # 해당 학생 사진틀에서 제거

        _dict[student] = [1, i]

print(*sorted(_dict.keys()))

```
