### PR TITLE
⭐️ 250814 : [BOJ 5639] 이진 검색 트리

### DIFF
--- a/_eunjin/18500_미네랄_2.py
+++ b/_eunjin/18500_미네랄_2.py
@@ -1,0 +1,149 @@
+from collections import deque
+import sys
+input = sys.stdin.readline
+R, C = map(int, input().split())
+
+matrix = [list(input().strip()) for _ in range(R)]
+
+N = int(input())
+height = list(map(int, input().split()))
+for i in range(N):
+    height[i] = R - height[i]  # y좌표 기준으로 변환
+
+def print_matrix(mat):
+    print('\n'.join(''.join(map(str, row)) for row in mat))
+
+# 막대가 날아가다 미네랄 만나면 해당 칸 미네랄 파괴, 막대 이동 종료
+# 미네랄 파괴 후 남은 클러스터가 분리되는 경우 가능함
+# 클러스터 분리된 경우: 중력 작용, 다른 클러스터나 땅을 만날때까지 떨어짐
+
+# 막대기 날리기, 행 h에서 방향 d로. 미네랄 만난 경우 해당 좌표 반환
+dd = [1, -1]  # 왼쪽, 오른쪽
+def throw(h, d):
+    y = h
+    if d == 0:  # 왼쪽 -> 오른쪽
+        x = 0
+        while x < C:
+            if matrix[y][x] == '.':
+                x += 1
+            else:
+                return y, x
+    else:  # 오른쪽 -> 왼쪽
+        x = C - 1
+        while x >= 0:
+            if matrix[y][x] == '.':
+                x -= 1
+            else:
+                return y, x
+
+    return -1, -1  # 미네랄 만나지 않은 경우
+
+
+# 해당 좌표부터 bfs탐색하며 떠있는 클러스터인지 판단하고 노드 좌표 리스트 반환
+dy = [1, 0, -1, 0]
+dx = [0, 1, 0, -1]
+def bfs(y, x):
+    q = deque()
+    valid = True
+    ret = []
+
+    q.append((y, x))
+    visited[y][x] = 1
+
+    while q:
+        y, x = q.popleft()
+        if y == R - 1:  # 바닥에 닿아있는 클러스터로, 분리 대상 아님
+            valid = False
+
+        ret.append([y, x])
+
+        for i in range(4):
+            ny, nx = y + dy[i], x + dx[i]
+            if ny < 0 or ny >= R or nx < 0 or nx >= C:
+                continue
+
+            if not visited[ny][nx] and matrix[ny][nx] == "x":
+                visited[ny][nx] = 1
+                q.append((ny, nx))
+
+    return valid, ret
+
+
+# 해당 클러스터를 몇칸까지 아래 이동 가능한지 반환
+def down_cnt(cluster):
+    cnt = 0
+    flag = True
+    while flag:
+        for y, x in cluster:
+            ny = y + cnt + 1
+            if ny >= R or (ny < R and matrix[ny][x] == "x"):
+                flag = False
+                break
+        if flag:
+            cnt += 1
+
+    return cnt
+
+
+# 해당 클러스터 중력 작용
+def drop(cluster):
+    cnt = down_cnt(cluster)  # 아래로 내릴 칸 수
+    for y, x in cluster:
+        matrix[y + cnt][x] = "x"
+
+
+for i in range(N):
+    my, mx = throw(height[i], i % 2)
+    if my == mx == -1:  # 미네랄 만나지 않음
+        continue
+
+    matrix[my][mx] = '.'  # 미네랄 파괴
+
+    cluster_cnt = 0
+    cluster = []
+    visited = [[0] * C for _ in range(R)]
+
+    # 행 방향 클러스터 탐색
+    if i % 2 == 0:  # 왼쪽 -> 오른쪽
+        if mx + 1 < C and matrix[my][mx + 1] == "x":
+            valid, cluster_row = bfs(my, mx + 1)  # 한 칸 오른쪽에서 bfs 시작
+            if valid:
+                cluster_cnt += 1
+                cluster = cluster_row
+    else:  # 오른쪽 -> 왼쪽
+        if mx - 1 >= 0 and matrix[my][mx - 1] == "x":
+            valid, cluster_row = bfs(my, mx - 1)  # 한 칸 왼쪽에서 bfs 시작
+            if valid:
+                cluster_cnt += 1
+                cluster = cluster_row
+
+    # 위 방향 클러스터 탐색
+    if my - 1 >= 0 and matrix[my - 1][mx] == "x" and not visited[my - 1][mx]:
+        valid, cluster_up = bfs(my - 1, mx)  # 바로 윗칸 시작
+        if valid:
+            cluster_cnt += 1
+            cluster = cluster_up
+
+    # 아래 방향 클러스터 탐색
+    if my + 1 < R and matrix[my + 1][mx] == "x" and not visited[my + 1][mx]:
+        valid, cluster_down = bfs(my + 1, mx)  # 바로 아래칸 시작
+        if valid:
+            cluster_cnt += 1
+            cluster = cluster_down
+
+    if cluster_cnt >= 2:
+        matrix[my][mx] = 'x'  # 미네랄 파괴 취소
+        continue
+
+    # 모든 방향 탐색했는데도 분리 대상 클러스터 없는 경우
+    if not cluster:
+        continue
+
+    # 클러스터 중력 작용을 위해 현재 클러스터 임시 삭제
+    for cy, cx in cluster:
+        matrix[cy][cx] = "."
+
+    # 클러스터 중력 작용
+    drop(cluster)
+
+print_matrix(matrix)

--- a/_eunjin/5639_이진_검색_트리.py
+++ b/_eunjin/5639_이진_검색_트리.py
@@ -1,0 +1,33 @@
+import sys
+input = sys.stdin.readline
+sys.setrecursionlimit(10**6)
+
+preorder = []
+while True:
+    try:
+        preorder.append(int(input()))
+    except:
+        break
+
+N = len(preorder)
+
+# 이진트리를 전위탐색할시에 부모 노드값은 배열[0]
+# 부모노드값보다 커지는 숫자가 나올때까지 왼쪽 서브트리 그 이후엔 오른쪽 서브 트리다.
+def dfs(start, end):
+    if start > end:
+        return
+
+    root = preorder[start]
+    split = end + 1
+
+    for i in range(start + 1, end + 1):
+        if preorder[i] > root:
+            split = i  # 오른쪽 서브트리가 시작되는 지점
+            break
+
+    # postorder: 왼쪽 -> 오른쪽 -> 루트 순으로 방문
+    dfs(start + 1, split - 1)  # 왼쪽
+    dfs(split, end)  # 오른쪽
+    print(root)
+
+dfs(0, N - 1)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1626}

## 🧩 문제 해결

**스스로 해결:** ❌ 45M

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** 트리, 재귀
- 🔹 **어떤 방식으로 접근했는지** 처음부터 재귀로 구현했어야 했는데 저는 이상하게 그냥 주어진 입력을 순차대로 탐색해서 딕셔너리에 {노드: [왼쪽 자식, 오른쪽 자식, 부모]}의 형태로 저장하려 했습니다. 그런데 주어진 입력에서 왼쪽 노드->오른쪽 노드로 전환되는 순간(왼쪽 서브트리가 끝나는 지점)을 처리할 수 없었습니다.. 여기서 더이상 방법을 모르겠어서 검색을 통해 해결했습니다. 
- 주어진 입력 자체가 특정 node의 왼쪽 서브 트리가 끝나면 오른쪽 서브트리가 나오고, 그 다음엔 node의 부모 노드의 오른쪽 서브트리가 나오는 재귀적인 구조라서 아예 재귀로 접근해야했습니다. 
- dfs함수로 탐색 구간을 파라미터로 받도록 했습니다. preorder 방문 시 start는 루트 노드가 되고, start+1 ~ end까지의 값 중 루트 노드보다 커지는 숫자가 나오는 그 이후 구간부터는 오른쪽 서브트리가 됩니다. 이를 이용해 split을 오른쪽 서브트리가 시작되는 지점으로 설정했습니다. 루트노드, 왼쪽 서브트리, 오른쪽 서브트리 구간을 모두 파악한 것이므로 여기서 이제 postorder(왼쪽->오른쪽->루트)로 방문하도록 dfs를 호출했습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N)`
- **이유:** 모든 노드를 한번씩 방문하므로

## 💻 구현 코드

```python
import sys
input = sys.stdin.readline
sys.setrecursionlimit(10**6)

preorder = []
while True:
    try:
        preorder.append(int(input()))
    except:
        break

N = len(preorder)

# 이진트리를 전위탐색할시에 부모 노드값은 배열[0]
# 부모노드값보다 커지는 숫자가 나올때까지 왼쪽 서브트리 그 이후엔 오른쪽 서브 트리다.
def dfs(start, end):
    if start > end:
        return

    root = preorder[start]
    split = end + 1

    for i in range(start + 1, end + 1):
        if preorder[i] > root:
            split = i  # 오른쪽 서브트리가 시작되는 지점
            break

    # postorder: 왼쪽 -> 오른쪽 -> 루트 순으로 방문
    dfs(start + 1, split - 1)  # 왼쪽
    dfs(split, end)  # 오른쪽
    print(root)

dfs(0, N - 1)

```
