### PR TITLE
⚡️ 250818 : [BOJ 1052] 물병

### DIFF
--- a/_hyunseo/1052_2.py
+++ b/_hyunseo/1052_2.py
@@ -1,0 +1,16 @@
+import math
+import sys
+
+input = sys.stdin.readline
+N, K = map(int, input().split())
+n = N
+bin_N = str(bin(n))[2:]
+
+added = 0
+
+while bin_N.count('1') > K :
+    added += 1
+    n += 1
+    bin_N = str(bin(n))[2:]
+    
+print(added)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1654}

## 🧩 문제 해결

**스스로 해결:** ✅ 

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** : 비트
- 🔹 **어떤 방식으로 접근했는지** : `성공`이라고 표시되어있어서 한번 더 풀어봤습니다. 과거에는 
```python
def get_two(num):
    two = 1
    while two < num :
        two *= 2
    return two
``` 
이런 식으로 주어진 수 중 가장 큰 2의 제곱을 구한 후, K과 비교, 만약 K보다 크다면 dfs 방식으로 (수 - 2의 제곱, K-1) 로 접근을 했었습니다. (지금 보니 이게 더 신기하네요....) 그때 비트마스킹?을 써야 한다는 블로그 글을 봤었는데, 실제 코드 구현은 하지 않았습니다. 그래서 이번에는 비트마스킹? 방법으로 접근해서 풀었습니다. bin으로 전환했을 때 1의 개수가 K개를 초과한 경우에는 하나씩 더하며, bin으로 전환했을 때 1의 개수가 K개 이하가 되도록 했습니다. 

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N log N)`
- **이유:** : bin()-> 이게 `O(log N)` 이네요. 최대 N번 순회하는데, 매번 bin계산을 하니 N log N 

## 💻 구현 코드

```python
import math
import sys

input = sys.stdin.readline
N, K = map(int, input().split())
n = N
bin_N = str(bin(n))[2:]

added = 0

while bin_N.count('1') > K :
    added += 1
    n += 1
    bin_N = str(bin(n))[2:]
    
print(added)


```


`while n.bit_count()>K: t=n&-n; added+=t; n+=t`으로 log N으로 줄일 수 있다고 합니다. 
매번 bit() 전환 -> 1 count가 아닌 정수.`bit_count()`를 사용하면 된다고 합니다!! 
