### PR TITLE
⭐️ 250821 : [BOJ 19598] 최소 회의실 개수

### DIFF
--- a/_eunjin/19598_최소_회의실_개수.py
+++ b/_eunjin/19598_최소_회의실_개수.py
@@ -1,0 +1,33 @@
+import sys
+import heapq
+input = sys.stdin.readline
+
+N = int(input())
+arr = [list(map(int, input().split())) for _ in range(N)]
+
+# 일단 주어진 arr을 시작 시간순으로 정렬
+# 우선순위큐에 각 회의실 회의 종료 시간 저장
+# 새 회의마다 큐에서 가장 빨리 회의 끝나는 회의실 뽑기
+# - 회의 종료시간이 새 회의의 회의 시작 시간보다 작거나 같으면 해당 회의실 이용 가능
+# - 회의 종료시간이 새 회의의 회의 시작 시간보다 크면 새 회의실 추가 배정
+
+arr.sort()
+
+pq = []
+answer = 0
+
+for start, end in arr:
+    if pq:
+        fastest = heapq.heappop(pq)  # 가장 빨리 회의 끝나는 회의실의 종료시간 뽑기
+        if fastest <= start:  # 해당 회의실 이용 가능
+            heapq.heappush(pq, end)
+        else:
+            heapq.heappush(pq, fastest)  # 회의실 다시 넣기
+            heapq.heappush(pq, end)  # 회의실 추가 배정
+            answer = max(answer, len(pq))
+    else:  # 새 회의실 배정
+        heapq.heappush(pq, end)
+        answer = max(answer, len(pq))
+
+
+print(answer)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1694}

## 🧩 문제 해결

**스스로 해결:** ✅ 13M

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** 우선순위큐, 정렬
- 🔹 **어떤 방식으로 접근했는지** 이런 비슷한 문제를 많이 만나봐서 바로 우선순위큐로 접근해야겠다고 생각했습니다. 새 회의마다 기존 회의실을 이용할지 새 회의실을 배정할지 여부를 결정하기 위해 가장 빨리 회의가 끝나는 회의실을 O(logN)에 접근할 수 있도록 우선순위큐를 사용했습니다. 큐에 각 회의실의 회의 종료 시간을 저장하고, 새 회의마다 큐에서 pop하며 가장 빨리 회의가 끝나는 회의실의 종료 시간을 얻었습니다. 회의 종료 시간이 새 회의의 회의 시작 시간보다 작거나 같으면 해당 회의실을 이용 가능한 것으로 판단했습니다. 회의 종료시간이 새 회의의 시작 시간보다 크면 새 회의실을 추가 배정해야 하는 것으로 판단해 pq에 두 회의실 정보를 push했습니다. 큐가 비어있는 경우에는 무조건 새 회의실 배정이 필요하므로 큐에 push해주었습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(NlogN)`
- **이유:** 큐에서 pop, push하는 `O(logN)` 짜리 연산을 총 N번 반복

## 💻 구현 코드

```python
import sys
import heapq
input = sys.stdin.readline

N = int(input())
arr = [list(map(int, input().split())) for _ in range(N)]

# 일단 주어진 arr을 시작 시간순으로 정렬
# 우선순위큐에 각 회의실 회의 종료 시간 저장
# 새 회의마다 큐에서 가장 빨리 회의 끝나는 회의실 뽑기
# - 회의 종료시간이 새 회의의 회의 시작 시간보다 작거나 같으면 해당 회의실 이용 가능
# - 회의 종료시간이 새 회의의 회의 시작 시간보다 크면 새 회의실 추가 배정

arr.sort()

pq = []
answer = 0

for start, end in arr:
    if pq:
        fastest = heapq.heappop(pq)  # 가장 빨리 회의 끝나는 회의실의 종료시간 뽑기
        if fastest <= start:  # 해당 회의실 이용 가능
            heapq.heappush(pq, end)
        else:
            heapq.heappush(pq, fastest)  # 회의실 다시 넣기
            heapq.heappush(pq, end)  # 회의실 추가 배정
            answer = max(answer, len(pq))
    else:  # 새 회의실 배정
        heapq.heappush(pq, end)
        answer = max(answer, len(pq))


print(answer)
```
