### PR TITLE
⭐️ 250821 : [BOJ 19598] 최소 회의실 개수

### DIFF
--- a/_jaewon/19598.py
+++ b/_jaewon/19598.py
@@ -1,0 +1,28 @@
+# N은 100,000까지. N^2 불가능
+import heapq
+import sys
+input = sys.stdin.readline
+
+N = int(input())
+time = []
+for _ in range(N):
+    time.append(tuple(map(int,input().split())))
+
+time.sort(key=lambda x: x[0])
+
+# 회의의 끝나는 시간을 저장하는 배열
+# 큐의 길이 == 회의실의 최소 개수
+queue = []
+heapq.heappush(queue, time[0][1])
+
+for i in range(1, N):
+    start, end = time[i]
+
+    # 가장 빨리 끝나는 회의실이 현재 회의 시작 전에 끝났다면 → 회의실 재사용
+    if queue[0] <= start:
+        heapq.heappop(queue)
+
+    # 현재 회의 끝나는 시간 push
+    heapq.heappush(queue, end)
+
+print(len(queue))


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1694}

## 🧩 문제 해결

**스스로 해결:** ✅ 

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지**: 우선순위 큐
- 🔹 **어떤 방식으로 접근했는지**

회의의 종료 시간을 우선순위 큐로 두고 풀었습니다.
종료 시간 중 최솟 값이, 현재 회의 시작 전이라면 그 회의실을 재사용 하는 로직입니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(NlogN)`
- **이유:**

## 💻 구현 코드

```py
# N은 100,000까지. N^2 불가능
import heapq
import sys
input = sys.stdin.readline

N = int(input())
time = []
for _ in range(N):
    time.append(tuple(map(int,input().split())))

time.sort(key=lambda x: x[0])

# 회의의 끝나는 시간을 저장하는 배열
# 큐의 길이 == 회의실의 최소 개수
queue = []
heapq.heappush(queue, time[0][1])

for i in range(1, N):
    start, end = time[i]

    # 가장 빨리 끝나는 회의실이 현재 회의 시작 전에 끝났다면 → 회의실 재사용
    if queue[0] <= start:
        heapq.heappop(queue)

    # 현재 회의 끝나는 시간 push
    heapq.heappush(queue, end)

print(len(queue))

```
