### PR TITLE
⭐️ 250826 : [BOJ 14284] 간선 이어가기 2

### DIFF
--- a/_eunjin/24284_간선_이어가기_2.py
+++ b/_eunjin/24284_간선_이어가기_2.py
@@ -1,0 +1,39 @@
+import sys
+import heapq
+input = sys.stdin.readline
+
+N, M = map(int, input().split())
+adj_list = [[] for _ in range(N + 1)]
+
+for _ in range(M):
+    a, b, c = map(int, input().split())
+    adj_list[a].append((b, c))
+    adj_list[b].append((a, c))
+
+start, end = map(int, input().split())
+INF = int(1e9)
+
+# 그냥 다익스트라로 두 노드 최단거리 찾는 문제
+
+dist = [INF] * (N + 1)
+
+def dijkstra(start):
+    q = []
+    heapq.heappush(q, (0, start))  # dist, start
+    dist[start] = 0
+
+    while q:
+        curr_dist, curr_node = heapq.heappop(q)
+
+        if dist[curr_node] < curr_dist:
+            continue
+
+        for adj_node, adj_dist in adj_list[curr_node]:
+            temp_dist = curr_dist + adj_dist
+            if temp_dist < dist[adj_node]:
+                dist[adj_node] = temp_dist
+                heapq.heappush(q, (temp_dist, adj_node))
+
+    return dist[end]
+
+print(dijkstra(start))


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1740}

## 🧩 문제 해결

**스스로 해결:** ✅ 17M

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** 다익스트라
- 🔹 **어떤 방식으로 접근했는지** 문제에서 "간선의 가중치의 합이 최소가 되게 추가하는 간선의 순서를 조정한다"라는 표현 때문에 조금 헷갈렸지만 주어진 입력에 대해 그림을 그려보니 결국에 그냥 s와 t 사이의 최단 거리를 구하는 문제였습니다. 다익스트라로 두 노드의 최단 거리를 찾도록 구현했습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(MlogN)`
- **이유:**

## 💻 구현 코드

```python
import sys
import heapq
input = sys.stdin.readline

N, M = map(int, input().split())
adj_list = [[] for _ in range(N + 1)]

for _ in range(M):
    a, b, c = map(int, input().split())
    adj_list[a].append((b, c))
    adj_list[b].append((a, c))

start, end = map(int, input().split())
INF = int(1e9)

# 그냥 다익스트라로 두 노드 최단거리 찾는 문제

dist = [INF] * (N + 1)

def dijkstra(start):
    q = []
    heapq.heappush(q, (0, start))  # dist, start
    dist[start] = 0

    while q:
        curr_dist, curr_node = heapq.heappop(q)

        if dist[curr_node] < curr_dist:
            continue

        for adj_node, adj_dist in adj_list[curr_node]:
            temp_dist = curr_dist + adj_dist
            if temp_dist < dist[adj_node]:
                dist[adj_node] = temp_dist
                heapq.heappush(q, (temp_dist, adj_node))

    return dist[end]

print(dijkstra(start))
```
