### PR TITLE
⭐️ 250826 : [BOJ 18116] 로봇 조립

### DIFF
--- a/_eunjin/18116_로봇_조립.py
+++ b/_eunjin/18116_로봇_조립.py
@@ -1,0 +1,36 @@
+import sys
+from collections import defaultdict
+input = sys.stdin.readline
+
+N = int(input())
+
+# 유니온 파인드
+
+def find(x):
+    if parent[x] != x:
+        parent[x] = find(parent[x])
+    return parent[x]
+
+def union(a, b):
+    a = find(a)
+    b = find(b)
+
+    if a == b:
+        return
+
+    parent[b] = a
+    _dict[a] += _dict[b]  # 부품 개수 누적
+
+parent = [i for i in range(10**6 + 1)]  # 부모 리스트 자기 자신으로 초기화
+_dict = defaultdict(lambda: 1)
+
+
+for _ in range(N):
+    cmd = list(input().split())
+    if cmd[0] == "I":
+        a = int(cmd[1])
+        b = int(cmd[2])
+        union(a, b)
+    else:
+        c = int(cmd[1])
+        print(_dict[find(c)])


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1739}

## 🧩 문제 해결

**스스로 해결:** ❌ 31M

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** 유니온 파인드
- 🔹 **어떤 방식으로 접근했는지** 주어진 두 부품은 어떤 로봇 하나의 부품이므로, 두 노드를 하나의 집합으로 묶는 유니온 파인드를 사용해야겠다고 생각했습니다. find 함수와 union함수로 유니온파인드 기본 구현까지는 했으나, 특정 집합에 속한 노드의 개수를 구하는 부분에서 답을 맞출 수 없었습니다.. N이 10^6이므로 특정 집합에 속한 노드의 개수를 구하는 시간복잡도가 O(N)보다 작아야 해서 노드의 개수를 _dict라는 딕셔너리에 저장하도록 했습니다. union함수에서 두 집합이 하나로 합쳐질 때 부품 개수도 같이 누적시키도록 했습니다. 여기까지 했는데도 오답이 나와서 정답을 검색해보니, union함수에서 a와 b가 서로 같은 집합에 속할 때는 먼저 return을 해주어서 부품 개수가 중복 누적되지 않도록 해야했습니다.. 이 부분을 놓쳐서 같은 집합에 속한 두 노드가 계속해서 입력으로 주어졌을 때 그만큼 부품 개수가 뻥튀기되는 오류가 있었습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N)`
- **이유:**

## 💻 구현 코드

```python
import sys
from collections import defaultdict
input = sys.stdin.readline

N = int(input())

# 유니온 파인드

def find(x):
    if parent[x] != x:
        parent[x] = find(parent[x])
    return parent[x]

def union(a, b):
    a = find(a)
    b = find(b)

    if a == b:
        return

    parent[b] = a
    _dict[a] += _dict[b]  # 부품 개수 누적

parent = [i for i in range(10**6 + 1)]  # 부모 리스트 자기 자신으로 초기화
_dict = defaultdict(lambda: 1)


for _ in range(N):
    cmd = list(input().split())
    if cmd[0] == "I":
        a = int(cmd[1])
        b = int(cmd[2])
        union(a, b)
    else:
        c = int(cmd[1])
        print(_dict[find(c)])
```
