### PR TITLE
⭐️ 250827 : [BOJ 9934] 완전 이진 트리

### DIFF
--- a/_eunjin/9934_완전_이진_트리.py
+++ b/_eunjin/9934_완전_이진_트리.py
@@ -1,0 +1,25 @@
+K = int(input())
+arr = list(map(int, input().split()))
+
+# 주어진 arr의 가운데 = root
+# arr 왼쪽 부분 = 왼쪽 서브트리
+# arr 오른쪽 부분 = 오른쪽 서브트리
+# 서브트리 안에서의 가운데 = 그 서브트리의 root
+# 서브트리로 좁혀갈 떄마다 depth +1
+
+answer = [[] for _ in range(K)]
+
+def recursion(start, end, depth):
+    if start == end:
+        answer[depth].append(arr[start])
+        return
+
+    root = (start + end) // 2
+    recursion(start, root - 1, depth + 1)
+    answer[depth].append(arr[root])
+    recursion(root + 1, end, depth + 1)
+
+recursion(0, len(arr) - 1, 0)
+
+for row in answer:
+    print(' '.join(map(str, row)))


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1755}

## 🧩 문제 해결

**스스로 해결:** ✅ 18M

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** 재귀
- 🔹 **어떤 방식으로 접근했는지** 주어진 빌딩 방문 순서가 결국에 inorder로 트리를 방문하는 순서이므로, 전체 주어진 방문 순서를 (왼쪽 서브트리 방문) + 루트 방문 + (오른쪽 서브트리 방문)의 구조로 볼 수 있습니다. 또, 각 서브트리 안에서의 가운데 노드가 곧 해당 서브트리의 루트가 됩니다. 전체를 서브트리와 루트로 나누기 -> 서브트리 하나 방문 -> 다시 서브트리로 나누기의 반복이므로, 재귀로 구현할 수 있었습니다. 구간의 시작 인덱스, 끝 인덱스, depth를 파라미터로 설정하고 주어진 구간의 root 인덱스를 구하도록 했습니다. 시작점~root 직전까지는 왼쪽 서브트리, root 직후~끝점까지는 오른쪽 서브트리로 판단해 다음 depth의 재귀를 호출했습니다. 시작점과 끝점이 같은 경우는 말단 노드에 도착한 것이므로, answer에 해당 노드를 추가하고 종료하도록 했습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(K)`
- **이유:**

## 💻 구현 코드

```python
K = int(input())
arr = list(map(int, input().split()))

# 주어진 arr의 가운데 = root
# arr 왼쪽 부분 = 왼쪽 서브트리
# arr 오른쪽 부분 = 오른쪽 서브트리
# 서브트리 안에서의 가운데 = 그 서브트리의 root
# 서브트리로 좁혀갈 떄마다 depth +1

answer = [[] for _ in range(K)]

def recursion(start, end, depth):
    if start == end:
        answer[depth].append(arr[start])
        return

    root = (start + end) // 2
    recursion(start, root - 1, depth + 1)
    answer[depth].append(arr[root])
    recursion(root + 1, end, depth + 1)

recursion(0, len(arr) - 1, 0)

for row in answer:
    print(' '.join(map(str, row)))
```
