### PR TITLE
⭐️ 250903 : [BOJ 22856] 트리 순회

### DIFF
--- a/_hyunseo/22856.py
+++ b/_hyunseo/22856.py
@@ -1,0 +1,42 @@
+import sys
+sys.setrecursionlimit(10**6)
+input = sys.stdin.readline
+
+N = int(input())
+left = {}
+right = {}
+
+for _ in range(N):
+    a, b, c = map(int, input().split())
+    left[a] = b
+    right[a] = c
+
+# 1. 중위 순회 마지막 노드 찾기
+def inorder_last(node):
+    if right[node] != -1:
+        return inorder_last(right[node])
+    return node
+
+last = inorder_last(1)  # 루트는 항상 1번
+
+# 2. 루트에서 마지막 노드까지 거리 구하기 (DFS)
+def dist(u, target, d=0):
+    if u == -1:
+        return -1
+    if u == target:
+        return d
+    # 왼쪽에서 찾기
+    ld = dist(left[u], target, d+1)
+    if ld != -1:
+        return ld
+    # 오른쪽에서 찾기
+    rd = dist(right[u], target, d+1)
+    if rd != -1:
+        return rd
+    return -1
+
+d = dist(1, last)
+
+# 3. 정답 계산
+answer = 2 * (N - 1) - d
+print(answer)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1825}

## 🧩 문제 해결

**스스로 해결:** ❌

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지**: DFS
- 🔹 **어떤 방식으로 접근했는지** : 저번 풀이에서 후위순회에서 사용했던 재귀를 사용하는 간단 경로 문제인줄 알고, tree라는 배열과 index를 사용해서 구현했는데, 시간초과 + stack overflow 문제가 발생해서 약 1시간 가량 고민하다가 정답을 참고했습니다. 그리고 트리 마지막 노드도 제가 생각했던 N이 아니어서, 이해하는데 오래 걸렸습니다. 마지막 노드는 결국 마지막으로 오른쪽으로 뻗었던 노드였었습니다.
- 참고한 답안은 다음과 같습니다. 
   - 배열에 노드를 저장하는 것이 아닌, 딕셔너리에 key를 부모 노드, 그리고 left, right에 각각 자식 노드를 저장했습니다.
   - `inorder_last` 함수를 통해서 가장 마지막으로 오른쪽으로 뻗었던 노드를 구합니다
   - dist(u, target)은 이 문제의 특성상, 만약 마지막 노드가 1로 돌아온다고 가정하면, 움직임은 총 2*(N-1) 이더라구요. 
   - 근데, 마지막 노드가 따로 존재하니, 1에서부터 마지막 노드까지의 거리만 구해서 그 값을 2*(N-1)에서 빼면 정답입니다.
   - 마지막 노드를 `inorder_last`을 통해서 구했으면, `dist` 함수를 통해서 거리를 구합니다. u를 시작으로 해서, DFS로 작동합니다. 1->->-> 거슬러 내려가서 target이 나올때까지 DFS를 반복해서 거리를 구합니다. 

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(?)`
- **이유:**

## 💻 구현 코드

```python
import sys
sys.setrecursionlimit(10**6)
input = sys.stdin.readline

N = int(input())
left = {}
right = {}

for _ in range(N):
    a, b, c = map(int, input().split())
    left[a] = b
    right[a] = c

# 1. 중위 순회 마지막 노드 찾기
def inorder_last(node):
    if right[node] != -1:
        return inorder_last(right[node])
    return node

last = inorder_last(1)  # 루트는 항상 1번

# 2. 루트에서 마지막 노드까지 거리 구하기 (DFS)
def dist(u, target, d=0):
    if u == -1:
        return -1
    if u == target:
        return d
    # 왼쪽에서 찾기
    ld = dist(left[u], target, d+1)
    if ld != -1:
        return ld
    # 오른쪽에서 찾기
    rd = dist(right[u], target, d+1)
    if rd != -1:
        return rd
    return -1

d = dist(1, last)

# 3. 정답 계산
answer = 2 * (N - 1) - d
print(answer)


```
