### PR TITLE
250924 : [BOJ 17352] 여러분의 다리가 되어 드리겠습니다!

### DIFF
--- a/_eunjin/17352_여러분의_다리가_되어_드리겠습니다.py
+++ b/_eunjin/17352_여러분의_다리가_되어_드리겠습니다.py
@@ -1,0 +1,44 @@
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+N = int(input())
+
+# 예외 케이스
+if N == 2:
+    print(1, 2)
+    exit()
+
+# 두 집단으로 나뉘어짐, 유니온 파인드로도 가능할듯???
+# 그냥 bfs로 하자
+adj_list = [[] for _ in range(N + 1)]
+
+for _ in range(N - 2):
+    a, b = map(int, input().split())
+    adj_list[a].append(b)
+    adj_list[b].append(a)
+
+# 1을 기준으로 bfs 탐색
+visited = [False] * (N + 1)
+q = deque()
+q.append(1)
+visited[1] = True
+
+while q:
+    node = q.popleft()
+
+    for adj_node in adj_list[node]:
+        if not visited[adj_node]:
+            q.append(adj_node)
+            visited[adj_node] = True
+
+if sum(visited) == 1:  # 1을 기준으로 bfs 돌렸을 때 방문한 노드 총 개수가 1개면 1이 끊어진 노드임
+    print(1, 2)
+else:
+    a, b = 0, 0  # 연결할 두 노드
+    for i in range(N, 0, -1):
+        if not visited[i]:
+            a = i
+        else:
+            b = i
+    print(a, b)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1947}

## 🧩 문제 해결

**스스로 해결:** ✅ 11M

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** bfs
- 🔹 **어떤 방식으로 접근했는지** 문제에 의하면 결국 그래프는 두 집단으로 나뉘게 되므로, 노드1을 기준으로 bfs를 돌려서 연결된 노드를 모두 방문한 후에 마지막에 아직 방문하지 못한 노드와 나머지 노드를 연결하는 것으로 취급해 출력했습니다. N이 2일때는 무조건 1과 2를 연결하면 되므로 아예 처음에 예외 케이스로 처리했습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N+N-2)`
- **이유:** bfs 시간복잡도 `O(V+E)`

## 💻 구현 코드

```python
import sys
from collections import deque
input = sys.stdin.readline

N = int(input())

# 예외 케이스
if N == 2:
    print(1, 2)
    exit()

# 두 집단으로 나뉘어짐, 유니온 파인드로도 가능할듯???
# 그냥 bfs로 하자
adj_list = [[] for _ in range(N + 1)]

for _ in range(N - 2):
    a, b = map(int, input().split())
    adj_list[a].append(b)
    adj_list[b].append(a)

# 1을 기준으로 bfs 탐색
visited = [False] * (N + 1)
q = deque()
q.append(1)
visited[1] = True

while q:
    node = q.popleft()

    for adj_node in adj_list[node]:
        if not visited[adj_node]:
            q.append(adj_node)
            visited[adj_node] = True

if sum(visited) == 1:  # 1을 기준으로 bfs 돌렸을 때 방문한 노드 총 개수가 1개면 1이 끊어진 노드임
    print(1, 2)
else:
    a, b = 0, 0  # 연결할 두 노드
    for i in range(N, 0, -1):
        if not visited[i]:
            a = i
        else:
            b = i
    print(a, b)
```
