### PR TITLE
250924 : [BOJ 21276] 계보 복원가 호석

### DIFF
--- a/_eunjin/21276_계보_복원가_호석.py
+++ b/_eunjin/21276_계보_복원가_호석.py
@@ -1,0 +1,53 @@
+import sys
+from collections import deque, defaultdict
+input = sys.stdin.readline
+
+N = int(input())
+names = list(input().split())
+
+# 이름: 인덱스 매핑
+names.sort()
+idx = {}
+for i, name in enumerate(names):
+    idx[name] = i
+
+# 위상정렬
+M = int(input())
+adj_list = [[] for _ in range(N)]
+indegree = [0] * N
+
+for _ in range(M):
+    a, b = input().split()
+    # b -> a (b가 a의 조상)
+    adj_list[idx[b]].append(idx[a])
+    indegree[idx[a]] += 1
+
+# print(names)
+# print(adj_list)
+
+# 최상위 조상 찾기
+roots = []
+q = deque()
+for i in range(N):
+    if indegree[i] == 0:
+        roots.append(names[i])
+        q.append(i)
+
+
+children = defaultdict(list)  # 직계 자식 기록용 dict
+
+while q:
+    cur = q.popleft()
+    for nxt in adj_list[cur]:
+        indegree[nxt] -= 1
+        if indegree[nxt] == 0:  # 진입차수가 0이 되는 노드만 다음 탐색 대상
+            children[names[cur]].append(names[nxt])
+            q.append(nxt)
+
+roots.sort()
+print(len(roots))
+print(*roots)
+
+for name in names:
+    kids = sorted(children[name])
+    print(name, len(kids), *kids)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1947}

## 🧩 문제 해결

**스스로 해결:** ❌

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** 위상정렬
- 🔹 **어떤 방식으로 접근했는지** 처음에는 유니온파인드로 해결이 가능하다고 생각했는데,, 어떻게 풀어야할지 방법을 모르겠어서 결국 검색을 해봤습니다. 유니온파인드로는 불가능했고, 방향이 있는 비순환그래프에서 자식 -> 부모 방향으로 탐색해야하는 위상정렬 문제였습니다.. 위상정렬 풀이 방법을 아직 익히지 못해서 추가 검색을 통해 문제를 이해했습니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N + M)`
- **이유:**

## 💻 구현 코드

```python
import sys
from collections import deque, defaultdict
input = sys.stdin.readline

N = int(input())
names = list(input().split())

# 이름: 인덱스 매핑
names.sort()
idx = {}
for i, name in enumerate(names):
    idx[name] = i

# 위상정렬
M = int(input())
adj_list = [[] for _ in range(N)]
indegree = [0] * N

for _ in range(M):
    a, b = input().split()
    # b -> a (b가 a의 조상)
    adj_list[idx[b]].append(idx[a])
    indegree[idx[a]] += 1

# print(names)
# print(adj_list)

# 최상위 조상 찾기
roots = []
q = deque()
for i in range(N):
    if indegree[i] == 0:
        roots.append(names[i])
        q.append(i)


children = defaultdict(list)  # 직계 자식 기록용 dict

while q:
    cur = q.popleft()
    for nxt in adj_list[cur]:
        indegree[nxt] -= 1
        if indegree[nxt] == 0:  # 진입차수가 0이 되는 노드만 다음 탐색 대상
            children[names[cur]].append(names[nxt])
            q.append(nxt)

roots.sort()
print(len(roots))
print(*roots)

for name in names:
    kids = sorted(children[name])
    print(name, len(kids), *kids)
```
