### PR TITLE
251022 : [BOJ 7453] 합이 0인 네 정수

### DIFF
--- a/_hyunseo/7453.py
+++ b/_hyunseo/7453.py
@@ -1,0 +1,26 @@
+import sys
+from collections import defaultdict
+
+input = sys.stdin.readline
+
+n = int(input())
+
+A, B, C, D = [], [], [], []
+
+for _ in range(n) :
+    a, b, c, d = map(int, input().split())
+    A.append(a)
+    B.append(b)
+    C.append(c)
+    D.append(d)
+
+dic = defaultdict(int)
+for a in A:
+    for b in B:
+        dic[a+b] += 1
+count = 0
+for c in C:
+    for d in D:
+        count += dic.get(-(c+d), 0)  # defaultdict보다 get()이 조금 더 빠름
+
+print(count)


### PR DESCRIPTION
Implement a solution to count pairs of sums.

## 🚀 이슈 번호

**Resolve:** {#2048}

## 🧩 문제 해결

**스스로 해결:** ❌

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** : ?
- 🔹 **어떤 방식으로 접근했는지** : python이라서 안된 문제였습니다.
- 처음에는 생각보다 N이 작아서, N**2 내로 풀면 되겠다, 싶어서 defaultdic에 저장하고 -> defaultdic을 순회하면서 (N**2), 이분탐색으로 나머지 값을 구하는 식으로 진행했는데, 결국에는 이렇게 복잡하게 생각할 것 없이 그냥 A,B 순회하면서 총합을 구해두고, C,D를 순회하면서 answer += dic[-(c+d)] 을 통해서 답을 구하도록 했습니다.
- 근데 시간 초과가 계속 나서 여러 가지 방법을 썼는데, 투포인터로 어떻게든 접근하려다가 결국 안돼서 정답을 참고했는데... defaultdic 자체 해시로 접근하는게 시간이 좀 걸려서, 이를 `dic.get()`으로 접근하면 시간초과가 나지 않더라구요. 

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(N**2)`
- **이유:**

## 💻 구현 코드

```python
import sys
from collections import defaultdict

input = sys.stdin.readline

n = int(input())

A, B, C, D = [], [], [], []

for _ in range(n) :
    a, b, c, d = map(int, input().split())
    A.append(a)
    B.append(b)
    C.append(c)
    D.append(d)

dic = defaultdict(int)
for a in A:
    for b in B:
        dic[a+b] += 1
count = 0
for c in C:
    for d in D:
        count += dic.get(-(c+d), 0)

print(count)

```
