### PR TITLE
251024 : [BOJ 22252] 정보 상인 호석

### DIFF
--- a/_eunjin/22252_정보_상인_호석.py
+++ b/_eunjin/22252_정보_상인_호석.py
@@ -1,0 +1,37 @@
+import sys
+import heapq
+input = sys.stdin.readline
+
+Q = int(input())
+
+# 각 이름마다 가치 높은 것 b개 뽑아야 함
+# 이름별 우선순위큐
+_dict = {}
+answer = 0
+
+for _ in range(Q):
+    cmd = list(input().split())
+    name = cmd[1]
+    if cmd[0] == "1":
+        nums = list(map(int, cmd[3:]))
+
+        if name not in _dict:  # 우선순위큐 초기화
+            _dict[name] = [-x for x in nums]
+            heapq.heapify(_dict[name])
+
+        else:
+            heap = _dict[name]
+            for x in nums:
+                heapq.heappush(heap, -x)
+    else:
+        b = int(cmd[2])
+        if name not in _dict:
+            continue
+
+        heap = _dict[name]
+        for _ in range(b):
+            if not heap:
+                break
+            answer -= heapq.heappop(heap)
+
+print(answer)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#2060}

## 🧩 문제 해결

**스스로 해결:** ✅

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** 해시맵, 우선순위큐
- 🔹 **어떤 방식으로 접근했는지** 각 이름마다 가치 높은 것 b개 뽑아야 하므로, 이름별 우선순위큐를 해시맵에 저장했습니다. 주어진 쿼리가 1로 시작하면 해당 이름을 key로 두고, 우선순위큐를 초기화했습니다. 이때, 최대힙으로 저장해야하므로 주어진 점수의 음수를 큐에 넣었습니다. 주어진 쿼리가 2로 시작하면 해당 이름의 value 우선순위큐에서 b만큼의 점수를 뽑았습니다. 
그런데 우선순위큐를 처음 선언할 때 아래처럼 먼저 nums 배열로 선언한 뒤에 한번에 heapify를 해야 시간초과가 발생하지 않았습니다. 처음에는 빈 배열로 선언한 뒤에 주어진 nums를 하나하나 heappush했는데 Python3, PyPy모두 시간초과가 계속 났습니다..
```python
        if name not in _dict:  # 우선순위큐 초기화
            _dict[name] = [-x for x in nums]
            heapq.heapify(_dict[name])
```
- heapify 시간복잡도: `O(N)`
- nums 각각 heappush 시간복잡도: `O(NlogN)`

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(?)`
- **이유:**

## 💻 구현 코드

```python
import sys
import heapq
input = sys.stdin.readline

Q = int(input())

# 각 이름마다 가치 높은 것 b개 뽑아야 함
# 이름별 우선순위큐
_dict = {}
answer = 0

for _ in range(Q):
    cmd = list(input().split())
    name = cmd[1]
    if cmd[0] == "1":
        nums = list(map(int, cmd[3:]))

        if name not in _dict:  # 우선순위큐 초기화
            _dict[name] = [-x for x in nums]
            heapq.heapify(_dict[name])

        else:
            heap = _dict[name]
            for x in nums:
                heapq.heappush(heap, -x)
    else:
        b = int(cmd[2])
        if name not in _dict:
            continue

        heap = _dict[name]
        for _ in range(b):
            if not heap:
                break
            answer -= heapq.heappop(heap)

print(answer)
```
