### PR TITLE
251119 : [BOJ 2263] 트리의 순회

### DIFF
--- a/2263.py
+++ b/2263.py
@@ -1,0 +1,33 @@
+import sys
+
+input = sys.stdin.readline
+sys.setrecursionlimit(10**6)
+N = int(input())
+
+inorder = list(map(int, input().split()))
+
+postorder = list(map(int, input().split()))
+
+inorder_idx = {val : idx for idx, val in enumerate(inorder)}
+
+preorder = []
+
+def preorder_find(in_start, in_end, post_start, post_end):
+    
+    if in_start > in_end or post_start > post_end :
+        return
+    root = postorder[post_end]
+    preorder.append(root)
+    
+    root_idx_inorder = inorder_idx[root]
+    left_subtree_size = root_idx_inorder - in_start
+    
+    preorder_find (in_start, root_idx_inorder-1, post_start, post_start + left_subtree_size - 1)
+    preorder_find(
+        root_idx_inorder + 1,
+        in_end,
+        post_start + left_subtree_size,
+        post_end - 1 )
+    
+preorder_find(0, N-1, 0, N-1)
+print(*preorder)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#2123}

## 🧩 문제 해결

**스스로 해결:**❌

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** :트리
- 🔹 **어떤 방식으로 접근했는지** : ㅠㅠ
- postorder에서는 항상 마지막 idx에 있는 노드가 root고,
- inorder에서는 root 기준으로 왼쪽 오른쪽 서브 트리가 명확하게 나뉜다는 점을 사용해서
- preorder로 다시 구성할 때는 root -> left -> right으로 가기 때문에 이를 사용해서 풀 수 있습니다.

inorder.index()를 사용하면 시간 초과가 나기 때문에, inorder_idx를 dictionary로 관리해서 시간 초과를 방지했고,

`find_preorder`라는 함수는,( depth으로 관리를 하면 오류가 떠서 결국 답안을 여기서 참고했습니다 ㅠㅠ)
inorder 시작점과 끝점, postorder 시작점과 끝점을 받은 후, postorder를 통해서 root를 찾고-> root_idx_inorder에 inorder 배영에서 root의 위치를 기억하도록 했습니다. 그다음 이걸 기준으로 preorder(왼쪽), preorder(오른쪽)을 찾도록 했습니다...



### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(?)`
- **이유:**

## 💻 구현 코드

```python
import sys

input = sys.stdin.readline
sys.setrecursionlimit(10**6)
N = int(input())

inorder = list(map(int, input().split()))

postorder = list(map(int, input().split()))

inorder_idx = {val : idx for idx, val in enumerate(inorder)}

preorder = []

def preorder_find(in_start, in_end, post_start, post_end):
    
    if in_start > in_end or post_start > post_end :
        return
    root = postorder[post_end]
    preorder.append(root)
    
    root_idx_inorder = inorder_idx[root]
    left_subtree_size = root_idx_inorder - in_start
    
    preorder_find (in_start, root_idx_inorder-1, post_start, post_start + left_subtree_size - 1)
    preorder_find(
        root_idx_inorder + 1,
        in_end,
        post_start + left_subtree_size,
        post_end - 1 )
    
preorder_find(0, N-1, 0, N-1)
print(*preorder)

```
