### PR TITLE
251120 : [BOJ 28707] 배열 정렬

### DIFF
--- a/_hyunseo/28707.py
+++ b/_hyunseo/28707.py
@@ -1,0 +1,54 @@
+import sys
+
+input = sys.stdin.readline
+# A의 길이 
+N = int(input())
+A = list(map(int, input().split()))
+
+#조작 개수
+M = int(input())
+L, R, C = [], [], []
+# L은 왼쪽 교체, R은 오른쪽 교체, C는 드는 비용
+for _ in range(M) :
+    a, b, c = map(int, input().split())
+    L.append(a-1)
+    R.append(b-1)
+    C.append(c)
+
+#비용 최솟값을 구하는 식, N < 10이니 bruteforce
+
+
+
+import heapq
+from collections import defaultdict
+
+q = []
+q.append([0, A])
+answer = sys.maxsize
+visited = set()
+flag = True
+
+visited = {}
+visited[tuple(A)] = 0
+while q :
+    cost, cur= heapq.heappop(q)
+    if sorted(cur) == cur :
+        print(cost)
+        sys.exit()
+        
+    cur_tuple = tuple(cur)
+    if cur_tuple in visited and visited[cur_tuple] < cost:
+        continue
+    
+    for i in range(M) :
+            cur[L[i]], cur[R[i]]= cur[R[i]],cur[L[i]]
+            nxt_cost = cost + C[i]
+            
+            nxt_cur = tuple(cur)
+            if nxt_cur not in visited or nxt_cost < visited[nxt_cur] :
+                visited[nxt_cur] = nxt_cost
+                heapq.heappush(q, [nxt_cost, cur[:]])
+
+            cur[L[i]], cur[R[i]]= cur[R[i]],cur[L[i]]
+
+print(-1)


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#2130}

## 🧩 문제 해결

**스스로 해결:** ✅

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** : 
- 🔹 **어떤 방식으로 접근했는지**: 처음 N이 10 이하다 보니, bruteforce로 접근 가능할 것 같았으나, 실제로 M이 있었기 때문에 N*M임을 고려하면, bruteforce로는 시간초과가 났습니다.
- 그러나 그걸 인지하지 못하고, 계속 bfs에서 가지치기를 추가했으나, 끝내 풀지 못했습니다
- 결국 방향을 틀어서 heapq를 사용하도록 했고, 원소들이 10이하임을 사용하면, ''.join(A)를 딕셔너리의 키 값, 그리고 거기까지의 방문 비용을 value로 저장해서, 가지치기를 하며 heap으로 접근했습니다. 
- 근데 ''.join을 하는 것보다 tuple()을 사용하면 더 편리합니다.

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.**  
> 최악의 경우 수행 시간은 어느 정도인지 분석합니다.

- **Big-O 표기법:** `O(?)`
- **이유:**

## 💻 구현 코드

```python
import sys

input = sys.stdin.readline
# A의 길이 
N = int(input())
A = list(map(int, input().split()))

#조작 개수
M = int(input())
L, R, C = [], [], []
# L은 왼쪽 교체, R은 오른쪽 교체, C는 드는 비용
for _ in range(M) :
    a, b, c = map(int, input().split())
    L.append(a-1)
    R.append(b-1)
    C.append(c)

#비용 최솟값을 구하는 식, N < 10이니 bruteforce -> 불가능!



import heapq
from collections import defaultdict

q = []
q.append([0, A])
answer = sys.maxsize
visited = set()
flag = True

visited = {}
visited[tuple(A)] = 0
while q :
    cost, cur= heapq.heappop(q)
    if sorted(cur) == cur :
        print(cost)
        sys.exit()
        
    cur_tuple = tuple(cur)
    if cur_tuple in visited and visited[cur_tuple] < cost:
        continue
    
    for i in range(M) :
            cur[L[i]], cur[R[i]]= cur[R[i]],cur[L[i]]
            nxt_cost = cost + C[i]
            
            nxt_cur = tuple(cur)
            if nxt_cur not in visited or nxt_cost < visited[nxt_cur] :
                visited[nxt_cur] = nxt_cost
                heapq.heappush(q, [nxt_cost, cur[:]])

            cur[L[i]], cur[R[i]]= cur[R[i]],cur[L[i]]

print(-1)
```
